### PR TITLE
feat: restore legacy tebako shim quartet (25 of 42 legacy functions)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,7 +512,12 @@ add_library(tfs STATIC
     "src/internal/memory_file_segment.cpp"
     "src/core/path.cpp"
     "src/core/config.cpp"
-    # Modern C API implementation (replaces old file-ctl/dir-ctl/file-io/dir-io)
+    # Modern C API implementation (successor to the legacy file-ctl/dir-ctl/file-io/dir-io
+    # quartet; the quartet is restored below under WITH_LEGACY_TEBAKO_API. The two layers
+    # export same-named extern "C" symbols -- tebako_open/tebako_read/tebako_lseek/
+    # tebako_close/tebako_stat/tebako_fstat/tebako_opendir/tebako_readdir/tebako_closedir --
+    # kept in separate objects so archive order (c_api first) keeps modern callers bound to
+    # this implementation; the modern API rename resolves the collision permanently)
     "src/c_api.cpp"
     "src/c_api/fs_context.cpp"
     "src/backend_registry.cpp"
@@ -531,11 +536,17 @@ add_library(tfs STATIC
   )
 
 # Legacy tebako C++ API (libdwarfs-wr lineage: tebako-io/memfs/fd/kfd, mount/fd
-# tables, cmdline, package descriptor). The modern API (c_api, backends,
-# fs_context, cli) has no dependency on this layer; it is skipped where
-# WITH_LEGACY_TEBAKO_API is OFF (standalone MinGW — see above).
+# tables, cmdline, package descriptor, and the restored POSIX-shim quartet
+# file-ctl/file-io/dir-ctl/dir-io implementing the legacy tebako_* libc surface).
+# The modern API (c_api, backends, fs_context, cli) has no dependency on this
+# layer; it is skipped where WITH_LEGACY_TEBAKO_API is OFF (standalone MinGW —
+# see above).
 if(WITH_LEGACY_TEBAKO_API)
   target_sources(tfs PRIVATE
+    "src/file-ctl.cpp"
+    "src/file-io.cpp"
+    "src/dir-ctl.cpp"
+    "src/dir-io.cpp"
     "src/dl-ctl.cpp"
     "src/tebako-cmdline.cpp"
     "src/tebako-io-helpers.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,11 +513,11 @@ add_library(tfs STATIC
     "src/core/path.cpp"
     "src/core/config.cpp"
     # Modern C API implementation (successor to the legacy file-ctl/dir-ctl/file-io/dir-io
-    # quartet; the quartet is restored below under WITH_LEGACY_TEBAKO_API. The two layers
-    # export same-named extern "C" symbols -- tebako_open/tebako_read/tebako_lseek/
-    # tebako_close/tebako_stat/tebako_fstat/tebako_opendir/tebako_readdir/tebako_closedir --
-    # kept in separate objects so archive order (c_api first) keeps modern callers bound to
-    # this implementation; the modern API rename resolves the collision permanently)
+    # quartet; the quartet is restored below under WITH_LEGACY_TEBAKO_API. The modern
+    # functions are namespaced tebako_fs_* -- tebako_fs_open/tebako_fs_read/tebako_fs_lseek/
+    # tebako_fs_close/tebako_fs_stat/tebako_fs_fstat/tebako_fs_opendir/tebako_fs_readdir/
+    # tebako_fs_closedir -- so they no longer collide with the legacy quartet's
+    # tebako_open/tebako_read/... exports, and mixed legacy+modern binaries link cleanly)
     "src/c_api.cpp"
     "src/c_api/fs_context.cpp"
     "src/backend_registry.cpp"

--- a/README.adoc
+++ b/README.adoc
@@ -88,10 +88,10 @@ Use the C API for Ruby integration:
 tebako_fs_init_from_file("app.dwarfs", "/__tebako__");
 
 // Use files
-int fd = tebako_open("/__tebako__/app.rb", O_RDONLY);
+int fd = tebako_fs_open("/__tebako__/app.rb", O_RDONLY);
 char buffer[4096];
-ssize_t n = tebako_read(fd, buffer, sizeof(buffer));
-tebako_close(fd);
+ssize_t n = tebako_fs_read(fd, buffer, sizeof(buffer));
+tebako_fs_close(fd);
 
 // Extract all files
 tebako_fs_extract_all("/output/directory");
@@ -373,19 +373,19 @@ module Tebako
     attach_function :tebako_is_initialized, [], :int
 
     # File operations
-    attach_function :tebako_open, [:string, :int], :int
-    attach_function :tebako_read, [:int, :pointer, :size_t], :ssize_t
-    attach_function :tebako_lseek, [:int, :off_t, :int], :off_t
-    attach_function :tebako_close, [:int], :int
+    attach_function :tebako_fs_open, [:string, :int], :int
+    attach_function :tebako_fs_read, [:int, :pointer, :size_t], :ssize_t
+    attach_function :tebako_fs_lseek, [:int, :off_t, :int], :off_t
+    attach_function :tebako_fs_close, [:int], :int
 
     # Directory operations
-    attach_function :tebako_opendir, [:string], :pointer
-    attach_function :tebako_readdir, [:pointer], :pointer
-    attach_function :tebako_closedir, [:pointer], :int
+    attach_function :tebako_fs_opendir, [:string], :pointer
+    attach_function :tebako_fs_readdir, [:pointer], :pointer
+    attach_function :tebako_fs_closedir, [:pointer], :int
 
     # Metadata
-    attach_function :tebako_stat, [:string, :pointer], :int
-    attach_function :tebako_fstat, [:int, :pointer], :int
+    attach_function :tebako_fs_stat, [:string, :pointer], :int
+    attach_function :tebako_fs_fstat, [:int, :pointer], :int
 
     # Extraction
     attach_function :tebako_fs_extract_all, [:string], :int
@@ -414,12 +414,12 @@ class File
     def read(path, *args)
       if Tebako::FileSystem.tebako_path_is_embedded(path) == 1
         # Read from libtfs
-        fd = Tebako::FileSystem.tebako_open(path, File::RDONLY)
+        fd = Tebako::FileSystem.tebako_fs_open(path, File::RDONLY)
         return nil if fd < 0
 
         buffer = FFI::MemoryPointer.new(:char, 1024 * 1024)
-        bytes_read = Tebako::FileSystem.tebako_read(fd, buffer, buffer.size)
-        Tebako::FileSystem.tebako_close(fd)
+        bytes_read = Tebako::FileSystem.tebako_fs_read(fd, buffer, buffer.size)
+        Tebako::FileSystem.tebako_fs_close(fd)
 
         bytes_read > 0 ? buffer.read_string(bytes_read) : nil
       else
@@ -700,10 +700,10 @@ int result = tebako_fs_init(
 
 if (result == 0) {
     // Files are now accessible
-    int fd = tebako_open("/__tebako__/app.rb", O_RDONLY);
+    int fd = tebako_fs_open("/__tebako__/app.rb", O_RDONLY);
     char buffer[1024];
-    ssize_t bytes = tebako_read(fd, buffer, sizeof(buffer));
-    tebako_close(fd);
+    ssize_t bytes = tebako_fs_read(fd, buffer, sizeof(buffer));
+    tebako_fs_close(fd);
 
     // Cleanup
     tebako_fs_unmount();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,10 +146,10 @@ namespace dwarfs {
 ```cpp
 // libdwarfs-wr API (C)
 extern "C" {
-  int tebako_open(const char* pathname, int flags);
-  ssize_t tebako_read(int fd, void* buf, size_t count);
-  int tebako_fstat(int fd, struct stat* statbuf);
-  int tebako_close(int fd);
+  int tebako_fs_open(const char* pathname, int flags);
+  ssize_t tebako_fs_read(int fd, void* buf, size_t count);
+  int tebako_fs_fstat(int fd, struct stat* statbuf);
+  int tebako_fs_close(int fd);
 }
 ```
 
@@ -181,7 +181,7 @@ extern "C" {
 │  • Memory Filesystem        [tebako-memfs.h]           │
 │                                                        │
 │  Path → FD → Inode Mapping:                           │
-│  • tebako_open() → FD allocation                      │
+│  • tebako_fs_open() → FD allocation                      │
 │  • FD → inode lookup                                  │
 │  • Mount point resolution                             │
 │  • Symbolic link traversal                            │
@@ -1059,8 +1059,8 @@ Any code depending on legacy API (unlikely, as it was internal) should use:
 
 | Legacy Function | Modern Equivalent |
 |----------------|-------------------|
-| Old file-ctl methods | `tebako_open()`, `tebako_read()`, `tebako_close()` |
-| Old dir-ctl methods | `tebako_opendir()`, `tebako_readdir()`, `tebako_closedir()` |
+| Old file-ctl methods | `tebako_fs_open()`, `tebako_fs_read()`, `tebako_fs_close()` |
+| Old dir-ctl methods | `tebako_fs_opendir()`, `tebako_fs_readdir()`, `tebako_fs_closedir()` |
 | Old file-io methods | Modern FileHandle class (internal) |
 | Old dir-io methods | Modern DirectoryIterator class (internal) |
 

--- a/docs/TEBAKO_INTEGRATION_GUIDE.adoc
+++ b/docs/TEBAKO_INTEGRATION_GUIDE.adoc
@@ -51,9 +51,9 @@ Ruby's mechanism for calling C functions from native libraries.
 │      (tebako/fs/c_api.h)                    │
 │                                             │
 │  • tebako_fs_init()                         │
-│  • tebako_open() / tebako_read()            │
-│  • tebako_opendir() / tebako_readdir()      │
-│  • tebako_stat()                            │
+│  • tebako_fs_open() / tebako_fs_read()            │
+│  • tebako_fs_opendir() / tebako_fs_readdir()      │
+│  • tebako_fs_stat()                            │
 │  • tebako_fs_extract_all()                  │
 └─────────────────┬───────────────────────────┘
                   │
@@ -177,26 +177,26 @@ module Tebako
     # @param path [String] File path
     # @param flags [Integer] Open flags (O_RDONLY, etc.)
     # @return [Integer] File descriptor or -1 on error
-    attach_function :tebako_open, [:string, :int], :fd_t
+    attach_function :tebako_fs_open, [:string, :int], :fd_t
 
     # Read from file
     # @param fd [Integer] File descriptor
     # @param buf [FFI::Pointer] Buffer to read into
     # @param count [Integer] Number of bytes to read
     # @return [Integer] Number of bytes read or -1 on error
-    attach_function :tebako_read, [:fd_t, :pointer, :size_t], :ssize_t
+    attach_function :tebako_fs_read, [:fd_t, :pointer, :size_t], :ssize_t
 
     # Seek within file
     # @param fd [Integer] File descriptor
     # @param offset [Integer] Offset to seek to
     # @param whence [Integer] SEEK_SET, SEEK_CUR, or SEEK_END
     # @return [Integer] New file position or -1 on error
-    attach_function :tebako_lseek, [:fd_t, :off_t, :int], :off_t
+    attach_function :tebako_fs_lseek, [:fd_t, :off_t, :int], :off_t
 
     # Close file
     # @param fd [Integer] File descriptor
     # @return [Integer] 0 on success, -1 on error
-    attach_function :tebako_close, [:fd_t], :int
+    attach_function :tebako_fs_close, [:fd_t], :int
 
     # ===============================================
     # Directory Operations
@@ -205,17 +205,17 @@ module Tebako
     # Open directory for reading
     # @param path [String] Directory path
     # @return [FFI::Pointer] Directory handle or NULL on error
-    attach_function :tebako_opendir, [:string], :dir_t
+    attach_function :tebako_fs_opendir, [:string], :dir_t
 
     # Read directory entry
     # @param dir [FFI::Pointer] Directory handle
     # @return [FFI::Pointer] Pointer to dirent structure or NULL
-    attach_function :tebako_readdir, [:dir_t], :pointer
+    attach_function :tebako_fs_readdir, [:dir_t], :pointer
 
     # Close directory
     # @param dir [FFI::Pointer] Directory handle
     # @return [Integer] 0 on success, -1 on error
-    attach_function :tebako_closedir, [:dir_t], :int
+    attach_function :tebako_fs_closedir, [:dir_t], :int
 
     # ===============================================
     # Metadata Operations
@@ -225,13 +225,13 @@ module Tebako
     # @param path [String] File path
     # @param statbuf [FFI::Pointer] Pointer to stat structure
     # @return [Integer] 0 on success, -1 on error
-    attach_function :tebako_stat, [:string, :pointer], :int
+    attach_function :tebako_fs_stat, [:string, :pointer], :int
 
     # Get file metadata by file descriptor
     # @param fd [Integer] File descriptor
     # @param statbuf [FFI::Pointer] Pointer to stat structure
     # @return [Integer] 0 on success, -1 on error
-    attach_function :tebako_fstat, [:fd_t, :pointer], :int
+    attach_function :tebako_fs_fstat, [:fd_t, :pointer], :int
 
     # ===============================================
     # Extraction Operations
@@ -304,17 +304,17 @@ module Tebako
         def read(path)
           return nil unless embedded?(path)
 
-          fd = Bindings.tebako_open(path, Bindings::O_RDONLY)
+          fd = Bindings.tebako_fs_open(path, Bindings::O_RDONLY)
           return nil if fd < 0
 
           begin
             # Allocate buffer (max 10MB for safety)
             buffer = FFI::MemoryPointer.new(:char, 10 * 1024 * 1024)
-            bytes_read = Bindings.tebako_read(fd, buffer, buffer.size)
+            bytes_read = Bindings.tebako_fs_read(fd, buffer, buffer.size)
 
             bytes_read > 0 ? buffer.read_string(bytes_read) : ""
           ensure
-            Bindings.tebako_close(fd)
+            Bindings.tebako_fs_close(fd)
           end
         end
 
@@ -323,7 +323,7 @@ module Tebako
           return false unless embedded?(path)
 
           stat_buf = FFI::MemoryPointer.new(:char, 144) # sizeof(struct stat)
-          result = Bindings.tebako_stat(path, stat_buf)
+          result = Bindings.tebako_fs_stat(path, stat_buf)
           result == 0
         end
 
@@ -332,7 +332,7 @@ module Tebako
           return nil unless embedded?(path)
 
           stat_buf = FFI::MemoryPointer.new(:char, 144)
-          return nil if Bindings.tebako_stat(path, stat_buf) != 0
+          return nil if Bindings.tebako_fs_stat(path, stat_buf) != 0
 
           # Extract st_size from stat structure (offset varies by platform)
           stat_buf.read_long_long
@@ -361,13 +361,13 @@ module Tebako
         def entries(path)
           return [] unless FileOps.embedded?(path)
 
-          dir = Bindings.tebako_opendir(path)
+          dir = Bindings.tebako_fs_opendir(path)
           return [] if dir.null?
 
           entries = []
           begin
             loop do
-              entry_ptr = Bindings.tebako_readdir(dir)
+              entry_ptr = Bindings.tebako_fs_readdir(dir)
               break if entry_ptr.null?
 
               # Read d_name from dirent structure
@@ -375,7 +375,7 @@ module Tebako
               entries << name unless name == "." || name == ".."
             end
           ensure
-            Bindings.tebako_closedir(dir)
+            Bindings.tebako_fs_closedir(dir)
           end
 
           entries

--- a/docs/TEBAKO_INTEGRATION_PLAN.md
+++ b/docs/TEBAKO_INTEGRATION_PLAN.md
@@ -109,19 +109,19 @@ tebako_fs_init(data, size, mount_point)  # For embedded archives
 tebako_fs_unmount()
 
 # File Operations
-tebako_open(path, flags)
-tebako_read(fd, buffer, count)
-tebako_lseek(fd, offset, whence)
-tebako_close(fd)
+tebako_fs_open(path, flags)
+tebako_fs_read(fd, buffer, count)
+tebako_fs_lseek(fd, offset, whence)
+tebako_fs_close(fd)
 
 # Directory Operations
-tebako_opendir(path)
-tebako_readdir(dir)
-tebako_closedir(dir)
+tebako_fs_opendir(path)
+tebako_fs_readdir(dir)
+tebako_fs_closedir(dir)
 
 # Metadata
-tebako_stat(path, statbuf)
-tebako_fstat(fd, statbuf)
+tebako_fs_stat(path, statbuf)
+tebako_fs_fstat(fd, statbuf)
 
 # Utilities
 tebako_path_is_embedded(path)
@@ -207,7 +207,7 @@ module Tebako
     class EmbeddedFile
       def initialize(path, mode = 'r')
         @path = path
-        @fd = Bindings.tebako_open(path, Bindings::O_RDONLY)
+        @fd = Bindings.tebako_fs_open(path, Bindings::O_RDONLY)
         raise Errno::ENOENT, path if @fd < 0
       end
 
@@ -220,7 +220,7 @@ module Tebako
       end
 
       def close
-        Bindings.tebako_close(@fd) if @fd >= 0
+        Bindings.tebako_fs_close(@fd) if @fd >= 0
         @fd = -1
       end
     end
@@ -228,7 +228,7 @@ module Tebako
     class EmbeddedDir
       def initialize(path)
         @path = path
-        @handle = Bindings.tebako_opendir(path)
+        @handle = Bindings.tebako_fs_opendir(path)
         raise Errno::ENOENT, path if @handle.null?
       end
 
@@ -237,7 +237,7 @@ module Tebako
       end
 
       def close
-        Bindings.tebako_closedir(@handle) unless @handle.null?
+        Bindings.tebako_fs_closedir(@handle) unless @handle.null?
       end
     end
   end
@@ -329,7 +329,7 @@ module Tebako
 
       def embedded_exist?(path)
         stat_buf = FFI::MemoryPointer.new(:char, 144)
-        Bindings.tebako_stat(path, stat_buf) == 0
+        Bindings.tebako_fs_stat(path, stat_buf) == 0
       end
     end
 
@@ -376,16 +376,16 @@ module Tebako
       private
 
       def embedded_entries(path)
-        dir = Bindings.tebako_opendir(path)
+        dir = Bindings.tebako_fs_opendir(path)
         return [] if dir.null?
 
         entries = []
         loop do
-          entry = Bindings.tebako_readdir(dir)
+          entry = Bindings.tebako_fs_readdir(dir)
           break if entry.null?
           entries << entry.read_string
         end
-        Bindings.tebako_closedir(dir)
+        Bindings.tebako_fs_closedir(dir)
         entries
       end
     end

--- a/include/tebako-pch.h
+++ b/include/tebako-pch.h
@@ -69,6 +69,12 @@ typedef SSIZE_T ssize_t;
 #endif
 #else
 #include <dirent.h>
+// With the legacy API enabled, include/tebako/fs is on the include path, so the
+// <dirent.h> above resolves to the shadow include/tebako/fs/dirent.h (the
+// tebako_dirent buffer abstraction) rather than the system header. Pull in the
+// real system dirent.h as well (DIR, struct dirent, fdopendir, scandir, ...) —
+// the legacy POSIX shims (dir-io.cpp) call it directly.
+#include_next <dirent.h>
 #include <unistd.h>
 #include <sys/param.h>
 #include <sys/uio.h>

--- a/include/tebako/fs/c_api.h
+++ b/include/tebako/fs/c_api.h
@@ -55,7 +55,7 @@ extern "C" {
 /**
  * @brief Flag bit to distinguish libtfs FDs from host OS FDs
  *
- * This bit is set on all file descriptors returned by tebako_open()
+ * This bit is set on all file descriptors returned by tebako_fs_open()
  * to ensure they never collide with host OS file descriptors.
  */
 #define TEBAKO_FD_FLAG 0x40000000
@@ -152,19 +152,19 @@ int tebako_is_initialized(void);
  * @return File descriptor on success (>0 with TEBAKO_FD_FLAG set), -1 on error
  *
  * @note Only read-only access is supported
- * @note The returned FD must be closed with tebako_close()
- * @note Do not use with standard close() - use tebako_close() instead
+ * @note The returned FD must be closed with tebako_fs_close()
+ * @note Do not use with standard close() - use tebako_fs_close() instead
  *
  * @example
  * @code
- * int fd = tebako_open("/__tebako__/config.txt", O_RDONLY);
+ * int fd = tebako_fs_open("/__tebako__/config.txt", O_RDONLY);
  * if (fd > 0) {
  *     // Read file...
- *     tebako_close(fd);
+ *     tebako_fs_close(fd);
  * }
  * @endcode
  */
-int tebako_open(const char* path, int flags);
+int tebako_fs_open(const char* path, int flags);
 
 /**
  * @brief Read from embedded file
@@ -172,14 +172,14 @@ int tebako_open(const char* path, int flags);
  * Reads up to count bytes from the file into buffer.
  * Behaves like POSIX read(2).
  *
- * @param fd File descriptor from tebako_open()
+ * @param fd File descriptor from tebako_fs_open()
  * @param buf Buffer to read into
  * @param count Maximum number of bytes to read
  * @return Number of bytes read (may be less than count), 0 on EOF, -1 on error
  *
  * @note Returns -1 with errno=EBADF if fd is not a valid libtfs FD
  */
-ssize_t tebako_read(int fd, void* buf, size_t count);
+ssize_t tebako_fs_read(int fd, void* buf, size_t count);
 
 /**
  * @brief Seek within embedded file
@@ -197,27 +197,27 @@ ssize_t tebako_read(int fd, void* buf, size_t count);
  * @example
  * @code
  * // Seek to byte 100
- * off_t pos = tebako_lseek(fd, 100, SEEK_SET);
+ * off_t pos = tebako_fs_lseek(fd, 100, SEEK_SET);
  *
  * // Get file size
- * off_t size = tebako_lseek(fd, 0, SEEK_END);
- * tebako_lseek(fd, 0, SEEK_SET);  // Reset to start
+ * off_t size = tebako_fs_lseek(fd, 0, SEEK_END);
+ * tebako_fs_lseek(fd, 0, SEEK_SET);  // Reset to start
  * @endcode
  */
-off_t tebako_lseek(int fd, off_t offset, int whence);
+off_t tebako_fs_lseek(int fd, off_t offset, int whence);
 
 /**
  * @brief Close embedded file
  *
  * Releases resources associated with the file descriptor.
  *
- * @param fd File descriptor from tebako_open()
+ * @param fd File descriptor from tebako_fs_open()
  * @return 0 on success, -1 on error
  *
  * @note After close, the FD becomes invalid
  * @note Safe to call multiple times with the same FD
  */
-int tebako_close(int fd);
+int tebako_fs_close(int fd);
 
 /* ============================================================
  * Directory Operations
@@ -247,21 +247,21 @@ struct tebako_c_dirent {
  * @param path Directory path
  * @return Directory handle on success, NULL on error
  *
- * @note The returned handle must be closed with tebako_closedir()
+ * @note The returned handle must be closed with tebako_fs_closedir()
  *
  * @example
  * @code
- * tebako_dir_t dir = tebako_opendir("/__tebako__/config");
+ * tebako_dir_t dir = tebako_fs_opendir("/__tebako__/config");
  * if (dir != NULL) {
  *     struct tebako_c_dirent* entry;
- *     while ((entry = tebako_readdir(dir)) != NULL) {
+ *     while ((entry = tebako_fs_readdir(dir)) != NULL) {
  *         printf("%s\n", entry->d_name);
  *     }
- *     tebako_closedir(dir);
+ *     tebako_fs_closedir(dir);
  * }
  * @endcode
  */
-tebako_dir_t tebako_opendir(const char* path);
+tebako_dir_t tebako_fs_opendir(const char* path);
 
 /**
  * @brief Read next directory entry
@@ -269,24 +269,24 @@ tebako_dir_t tebako_opendir(const char* path);
  * Returns the next entry in the directory. Returns NULL when
  * no more entries or on error.
  *
- * @param dir Directory handle from tebako_opendir()
+ * @param dir Directory handle from tebako_fs_opendir()
  * @return Pointer to entry structure, or NULL at end/error
  *
- * @note The returned pointer is valid until next call to tebako_readdir()
- *       or tebako_closedir()
+ * @note The returned pointer is valid until next call to tebako_fs_readdir()
+ *       or tebako_fs_closedir()
  * @note Entries "." and ".." are excluded
  */
-struct tebako_c_dirent* tebako_readdir(tebako_dir_t dir);
+struct tebako_c_dirent* tebako_fs_readdir(tebako_dir_t dir);
 
 /**
  * @brief Close directory handle
  *
  * Releases resources associated with the directory handle.
  *
- * @param dir Directory handle from tebako_opendir()
+ * @param dir Directory handle from tebako_fs_opendir()
  * @return 0 on success, -1 on error
  */
-int tebako_closedir(tebako_dir_t dir);
+int tebako_fs_closedir(tebako_dir_t dir);
 
 /* ============================================================
  * Metadata Operations
@@ -307,7 +307,7 @@ int tebako_closedir(tebako_dir_t dir);
  * @example
  * @code
  * struct stat st;
- * if (tebako_stat("/__tebako__/file.txt", &st) == 0) {
+ * if (tebako_fs_stat("/__tebako__/file.txt", &st) == 0) {
  *     printf("Size: %lld bytes\n", (long long)st.st_size);
  *     if (S_ISREG(st.st_mode)) {
  *         printf("Regular file\n");
@@ -315,18 +315,18 @@ int tebako_closedir(tebako_dir_t dir);
  * }
  * @endcode
  */
-int tebako_stat(const char* path, struct stat* st);
+int tebako_fs_stat(const char* path, struct stat* st);
 
 /**
  * @brief Get file status via file descriptor
  *
- * Like tebako_stat() but takes a file descriptor.
+ * Like tebako_fs_stat() but takes a file descriptor.
  *
- * @param fd File descriptor from tebako_open()
+ * @param fd File descriptor from tebako_fs_open()
  * @param st Pointer to stat structure to fill
  * @return 0 on success, -1 on error
  */
-int tebako_fstat(int fd, struct stat* st);
+int tebako_fs_fstat(int fd, struct stat* st);
 
 /* ============================================================
  * Path Detection
@@ -344,7 +344,7 @@ int tebako_fstat(int fd, struct stat* st);
  * @example
  * @code
  * if (tebako_path_is_embedded("/__tebako__/file.txt")) {
- *     // Use tebako_open()
+ *     // Use tebako_fs_open()
  * } else {
  *     // Use regular open()
  * }
@@ -355,7 +355,7 @@ int tebako_path_is_embedded(const char* path);
 /**
  * @brief Check if file descriptor is from libtfs
  *
- * Tests if a file descriptor was returned by tebako_open().
+ * Tests if a file descriptor was returned by tebako_fs_open().
  *
  * @param fd File descriptor to check
  * @return 1 if FD is from libtfs, 0 otherwise

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -78,7 +78,7 @@ int g_next_fd = 1;  // Internal FD counter (starts at 1)
 // DIR handle table: opaque pointer -> DirectoryIterator + cached entry
 struct DirectoryState {
   std::unique_ptr<tebako::fs::DirectoryIterator> iterator;
-  tebako_c_dirent current_entry;  // Cached for tebako_readdir return
+  tebako_c_dirent current_entry;  // Cached for tebako_fs_readdir return
   bool has_current;
 };
 std::unordered_map<void*, std::unique_ptr<DirectoryState>> g_dir_table;
@@ -456,7 +456,7 @@ extern "C" int tebako_is_initialized(void)
 // File Operations
 // ===================================================================
 
-extern "C" int tebako_open(const char* path, int flags)
+extern "C" int tebako_fs_open(const char* path, int flags)
 {
   if (path == nullptr) {
     set_errno(EINVAL);
@@ -490,7 +490,7 @@ extern "C" int tebako_open(const char* path, int flags)
   }
 }
 
-extern "C" ssize_t tebako_read(int fd, void* buf, size_t count)
+extern "C" ssize_t tebako_fs_read(int fd, void* buf, size_t count)
 {
   if (buf == nullptr) {
     set_errno(EINVAL);
@@ -519,7 +519,7 @@ extern "C" ssize_t tebako_read(int fd, void* buf, size_t count)
   }
 }
 
-extern "C" off_t tebako_lseek(int fd, off_t offset, int whence)
+extern "C" off_t tebako_fs_lseek(int fd, off_t offset, int whence)
 {
   auto* handle = get_handle(fd);
   if (handle == nullptr) {
@@ -543,7 +543,7 @@ extern "C" off_t tebako_lseek(int fd, off_t offset, int whence)
   }
 }
 
-extern "C" int tebako_close(int fd)
+extern "C" int tebako_fs_close(int fd)
 {
   auto* handle = get_handle(fd);
   if (handle == nullptr) {
@@ -569,7 +569,7 @@ extern "C" int tebako_close(int fd)
 // Directory Operations
 // ===================================================================
 
-extern "C" tebako_dir_t tebako_opendir(const char* path)
+extern "C" tebako_dir_t tebako_fs_opendir(const char* path)
 {
   if (path == nullptr) {
     set_errno(EINVAL);
@@ -597,7 +597,7 @@ extern "C" tebako_dir_t tebako_opendir(const char* path)
   }
 }
 
-extern "C" struct tebako_c_dirent* tebako_readdir(tebako_dir_t dir)
+extern "C" struct tebako_c_dirent* tebako_fs_readdir(tebako_dir_t dir)
 {
   auto* state = get_dir_state(dir);
   if (state == nullptr || state->iterator == nullptr) {
@@ -629,7 +629,7 @@ extern "C" struct tebako_c_dirent* tebako_readdir(tebako_dir_t dir)
   }
 }
 
-extern "C" int tebako_closedir(tebako_dir_t dir)
+extern "C" int tebako_fs_closedir(tebako_dir_t dir)
 {
   if (!remove_dir_handle(dir)) {
     set_errno(EBADF);
@@ -644,7 +644,7 @@ extern "C" int tebako_closedir(tebako_dir_t dir)
 // Metadata Operations
 // ===================================================================
 
-extern "C" int tebako_stat(const char* path, struct stat* st)
+extern "C" int tebako_fs_stat(const char* path, struct stat* st)
 {
   if (path == nullptr || st == nullptr) {
     set_errno(EINVAL);
@@ -712,7 +712,7 @@ extern "C" int tebako_stat(const char* path, struct stat* st)
   }
 }
 
-extern "C" int tebako_fstat(int fd, struct stat* st)
+extern "C" int tebako_fs_fstat(int fd, struct stat* st)
 {
   if (st == nullptr) {
     set_errno(EINVAL);
@@ -727,7 +727,7 @@ extern "C" int tebako_fstat(int fd, struct stat* st)
 
   try {
     // Use path from handle to call stat
-    return tebako_stat(handle->path().c_str(), st);
+    return tebako_fs_stat(handle->path().c_str(), st);
   }
   catch (...) {
     handle_exception();

--- a/src/dir-ctl.cpp
+++ b/src/dir-ctl.cpp
@@ -1,0 +1,217 @@
+/**
+ *
+ * Copyright (c) 2021-2025, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ * This file is a part of the Tebako project. (libdwarfs-wr)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <tebako-pch.h>
+#include <tebako-pch-pp.h>
+#include <tebako/fs/common.h>
+#include <tebako/fs/dirent.h>
+#include <tebako/fs/io.h>
+#include <tebako-io-inner.h>
+#include <tebako/fs/ruby/io_rb_w32_inner.h>
+#include <tebako-io-root.h>
+
+using namespace tebako;
+
+char* tebako_getcwd(char* buf, size_t size)
+{
+  tebako_path_t _cwd;
+  const char* cwd = tebako_get_cwd(_cwd, true);
+  size_t len = strlen(cwd);
+  if (len) {
+    if (!buf) {
+      if (!size) {
+        buf = strdup(cwd);
+        if (!buf) {
+          TEBAKO_SET_LAST_ERROR(ENOMEM);
+        }
+      }
+      else {
+        if (len > size - 1) {
+          TEBAKO_SET_LAST_ERROR(ERANGE);
+          buf = NULL;
+        }
+        else {
+          buf = (char*)malloc(size);
+          if (!buf) {
+            TEBAKO_SET_LAST_ERROR(ENOMEM);
+          }
+          else {
+            strcpy(buf, cwd);
+          }
+        }
+      }
+    }
+    else {
+      if (!size) {
+        TEBAKO_SET_LAST_ERROR(EINVAL);
+        buf = NULL;
+      }
+      else if (len > size - 1) {
+        TEBAKO_SET_LAST_ERROR(ERANGE);
+        buf = NULL;
+      }
+      else
+        strcpy(buf, cwd);
+    }
+    return buf;
+  }
+  else
+    return TO_RB_W32_U(getcwd)(buf, size);
+}
+
+int tebako_chdir(const char* path)
+{
+  int ret = DWARFS_IO_ERROR;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+
+    if (p_path) {
+      struct STAT_TYPE st;
+      ret = tebako_stat(p_path, &st);
+      if (ret == 0) {
+        if (S_ISDIR(st.st_mode)) {
+          ret = tebako_set_cwd(p_path) ? 0 : -1;
+          if (ret != 0) {
+            TEBAKO_SET_LAST_ERROR(ENOMEM);
+          }
+        }
+        else {
+          ret = -1;
+          TEBAKO_SET_LAST_ERROR(ENOTDIR);
+        }
+      }
+    }
+    else {
+      ret = TO_RB_W32_U(chdir)(path);
+      if (ret == 0) {
+        ret = tebako_set_cwd(NULL) ? 0 : -1;
+        if (ret != 0) {
+          TEBAKO_SET_LAST_ERROR(ENOMEM);
+        }
+      }
+    }
+  }
+
+  return ret;
+}
+
+#if defined(TEBAKO_HAS_POSIX_MKDIR) || defined(RB_W32)
+int tebako_mkdir(const char* path, mode_t mode)
+{
+#else
+int tebako_mkdir(const char* path)
+{
+#endif
+  int ret = DWARFS_IO_ERROR;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+      std::string lnk;
+      struct stat st;
+      if (dwarfs_stat(p_path, &st, lnk, true) == DWARFS_S_LINK_OUTSIDE) {
+#if defined(TEBAKO_HAS_POSIX_MKDIR) || defined(RB_W32)
+        ret = TO_RB_W32_U(mkdir)(lnk.c_str(), mode);
+#else
+        ret = ::mkdir(lnk.c_str());
+#endif
+      }
+      else {
+        TEBAKO_SET_LAST_ERROR(EROFS);
+      }
+    }
+    else {
+#if defined(TEBAKO_HAS_POSIX_MKDIR) || defined(RB_W32)
+      ret = TO_RB_W32_U(mkdir)(path, mode);
+#else
+      ret = ::mkdir(path);
+#endif
+    }
+  }
+  return ret;
+}
+
+int tebako_rmdir(const char* path)
+{
+  int ret = DWARFS_IO_ERROR;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+      std::string lnk;
+      struct stat st;
+      if (dwarfs_stat(p_path, &st, lnk, true) == DWARFS_S_LINK_OUTSIDE) {
+        ret = TO_RB_W32_U(rmdir)(lnk.c_str());
+      }
+      else {
+        TEBAKO_SET_LAST_ERROR(EROFS);
+      }
+    }
+    else {
+      ret = TO_RB_W32_U(rmdir)(path);
+    }
+  }
+  return ret;
+}
+
+int tebako_unlink(const char* path)
+{
+  int ret = DWARFS_IO_ERROR;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+      std::string lnk;
+      struct stat st;
+      if (dwarfs_stat(p_path, &st, lnk, true) == DWARFS_S_LINK_OUTSIDE) {
+        ret = TO_RB_W32_U(unlink)(lnk.c_str());
+      }
+      else {
+        TEBAKO_SET_LAST_ERROR(EROFS);
+      }
+    }
+    else {
+      ret = TO_RB_W32_U(unlink)(path);
+    }
+  }
+  return ret;
+}

--- a/src/dir-io.cpp
+++ b/src/dir-io.cpp
@@ -1,0 +1,306 @@
+/**
+ *
+ * Copyright (c) 2021-2025, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ * This file is a part of the Tebako project. (libdwarfs-wr)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <tebako-pch.h>
+#include <tebako-pch-pp.h>
+#include <tebako/fs/common.h>
+#include <tebako/fs/dirent.h>
+#include <tebako/fs/io.h>
+#include <tebako-io-inner.h>
+#include <tebako/fs/ruby/io_rb_w32_inner.h>
+#include <tebako-io-root.h>
+#include <tebako/fs/internal/fd_table.h>
+#include <tebako/fs/internal/kfd.h>
+
+using namespace tebako;
+
+#if defined(TEBAKO_HAS_OPENDIR) || defined(RB_W32)
+DIR* tebako_opendir(const char* dirname)
+{
+  DIR* ret = NULL;
+  if (dirname == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    int vfd;
+    tebako_path_t t_path;
+    std::string r_dirname = dirname;
+    const char* p_path = to_tebako_path(t_path, dirname);
+
+    if (p_path) {
+      vfd = sync_tebako_fdtable::get_tebako_fdtable().open(p_path, O_RDONLY | O_DIRECTORY, r_dirname);
+      switch (vfd) {
+        case DWARFS_S_LINK_OUTSIDE:
+          break;
+        case DWARFS_INVALID_FD:
+          ret = NULL;
+          TEBAKO_SET_LAST_ERROR(ENOENT);
+          break;
+        case DWARFS_IO_ERROR:
+          ret = NULL;
+          break;
+        default:
+          ret = reinterpret_cast<DIR*>(sync_tebako_dstable::get_tebako_dstable().opendir(vfd));
+          break;
+      }
+    }
+
+    if (!p_path || vfd == DWARFS_S_LINK_OUTSIDE) {
+      ret = TO_RB_W32_U(opendir)(r_dirname.c_str());
+      if (ret != NULL) {
+        sync_tebako_kfdtable::get_tebako_kfdtable().insert(reinterpret_cast<uintptr_t>(ret));
+      }
+    }
+  }
+  return ret;
+}
+#endif
+
+#ifdef TEBAKO_HAS_FDOPENDIR
+DIR* tebako_fdopendir(int vfd)
+{
+  DIR* ret = reinterpret_cast<DIR*>(sync_tebako_dstable::get_tebako_dstable().opendir(vfd));
+  if (ret == NULL) {
+    ret = ::fdopendir(vfd);
+    if (ret != NULL) {
+      sync_tebako_kfdtable::get_tebako_kfdtable().insert(reinterpret_cast<uintptr_t>(ret));
+    }
+  }
+  return ret;
+}
+#endif
+
+#if defined(TEBAKO_HAS_CLOSEDIR) || defined(RB_W32)
+int tebako_closedir(DIR* dirp)
+{
+  int ret = DWARFS_IO_ERROR;
+  uintptr_t uip = reinterpret_cast<uintptr_t>(dirp);
+  ret = sync_tebako_dstable::get_tebako_dstable().closedir(uip);
+  if (ret == DWARFS_INVALID_FD) {
+    if (!sync_tebako_kfdtable::get_tebako_kfdtable().check(uip)) {
+      ret = DWARFS_IO_ERROR;
+      TEBAKO_SET_LAST_ERROR(EBADF);
+    }
+    else {
+#ifdef _WIN32
+      ret = DWARFS_IO_CONTINUE;
+#else
+      ret =
+#endif
+      TO_RB_W32(closedir)(dirp);
+      sync_tebako_kfdtable::get_tebako_kfdtable().erase(uip);
+    }
+  }
+  return ret;
+}
+#endif
+
+#if defined(TEBAKO_HAS_READDIR) || defined(RB_W32)
+#if defined(RB_W32)
+struct direct* tebako_readdir(DIR* dirp, void* enc)
+{
+  struct direct* entry = NULL;
+#else
+struct dirent* tebako_readdir(DIR* dirp)
+{
+  struct dirent* entry = NULL;
+#endif
+  tebako_dirent* e = NULL;
+  int ret = DWARFS_IO_ERROR;
+  uintptr_t uip = reinterpret_cast<uintptr_t>(dirp);
+  ret = sync_tebako_dstable::get_tebako_dstable().readdir(uip, e);
+  if (ret == DWARFS_INVALID_FD) {
+    if (!sync_tebako_kfdtable::get_tebako_kfdtable().check(uip)) {
+      ret = DWARFS_IO_ERROR;
+      TEBAKO_SET_LAST_ERROR(EBADF);
+    }
+    else {
+#if defined(RB_W32)
+      entry = TO_RB_W32(readdir)(dirp, enc);
+#else
+      entry = TO_RB_W32(readdir)(dirp);
+#endif
+    }
+  }
+  else {
+#if defined(RB_W32)
+    entry = e ? &e->e : nullptr;
+#else
+    // tebako/fs/dirent.h (the current tebako_dirent) exposes the entry buffer
+    // as void* via e(); the legacy union exposed struct dirent* directly.
+    entry = e ? static_cast<struct dirent*>(e->e()) : nullptr;
+#endif
+  }
+  return entry;
+}
+#endif
+
+#if defined(TEBAKO_HAS_TELLDIR) || defined(RB_W32)
+long tebako_telldir(DIR* dirp)
+{
+  long ret = DWARFS_IO_ERROR;
+  uintptr_t uip = reinterpret_cast<uintptr_t>(dirp);
+  ret = sync_tebako_dstable::get_tebako_dstable().telldir(uip);
+  if (ret == DWARFS_INVALID_FD) {
+    if (!sync_tebako_kfdtable::get_tebako_kfdtable().check(uip)) {
+      ret = DWARFS_IO_ERROR;
+      TEBAKO_SET_LAST_ERROR(EBADF);
+    }
+    else {
+      ret = TO_RB_W32(telldir)(dirp);
+    }
+  }
+  return ret;
+}
+#endif
+
+#if defined(TEBAKO_HAS_SEEKDIR) || defined(RB_W32)
+void tebako_seekdir(DIR* dirp, long loc)
+{
+  int ret = DWARFS_IO_ERROR;
+  uintptr_t uip = reinterpret_cast<uintptr_t>(dirp);
+  ret = sync_tebako_dstable::get_tebako_dstable().seekdir(uip, loc);
+  if (ret == DWARFS_INVALID_FD) {
+    if (!sync_tebako_kfdtable::get_tebako_kfdtable().check(uip)) {
+      TEBAKO_SET_LAST_ERROR(EBADF);
+    }
+    else {
+      TO_RB_W32(seekdir)(dirp, loc);
+    }
+  }
+}
+#endif
+
+#ifdef TEBAKO_HAS_DIRFD
+int tebako_dirfd(DIR* dirp)
+{
+  int ret = DWARFS_IO_ERROR;
+  uintptr_t uip = reinterpret_cast<uintptr_t>(dirp);
+  ret = sync_tebako_dstable::get_tebako_dstable().dirfd(uip);
+  if (ret == DWARFS_INVALID_FD) {
+    if (!sync_tebako_kfdtable::get_tebako_kfdtable().check(uip)) {
+      ret = DWARFS_IO_ERROR;
+      TEBAKO_SET_LAST_ERROR(EBADF);
+    }
+    else {
+      ret = ::dirfd(dirp);
+    }
+  }
+  return ret;
+}
+#endif
+
+#ifdef TEBAKO_HAS_SCANDIR
+typedef int (*qsort_compar)(const void*, const void*);
+
+static struct dirent* internal_readdir(DIR* dirp)
+{
+  tebako_dirent* entry = NULL;
+  sync_tebako_dstable::get_tebako_dstable().readdir(reinterpret_cast<uintptr_t>(dirp), entry);
+  return entry ? static_cast<struct dirent*>(entry->e()) : nullptr;
+}
+
+int tebako_scandir(const char* dirname,
+                   struct dirent*** namelist,
+                   int (*sel)(const struct dirent*),
+                   int (*compar)(const struct dirent**, const struct dirent**))
+{
+  int ret = DWARFS_IO_ERROR;
+  if (dirname == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    int vfd;
+    std::string dirname_r = dirname;
+    DIR* dirp = NULL;
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, dirname);
+
+    if (p_path) {
+      vfd = sync_tebako_fdtable::get_tebako_fdtable().open(p_path, O_RDONLY | O_DIRECTORY, dirname_r);
+    }
+    if (!p_path || vfd == DWARFS_S_LINK_OUTSIDE) {
+      ret = ::scandir(dirname_r.c_str(), namelist, sel, compar);
+    }
+    else {
+      if (namelist != NULL) {
+        if (vfd == DWARFS_INVALID_FD) {
+          TEBAKO_SET_LAST_ERROR(ENOENT);
+          vfd = DWARFS_IO_ERROR;
+        }
+        if (vfd >= DWARFS_IO_CONTINUE) {
+          size_t size;
+          dirp = reinterpret_cast<DIR*>(sync_tebako_dstable::get_tebako_dstable().opendir(vfd, size));
+          if (dirp != NULL) {
+            int n = 0;
+            dirent** list = (dirent**)malloc(sizeof(dirent*) * size);
+            dirent *ent = 0, *p = 0;
+            while (list != NULL && (ent = internal_readdir(dirp)) != NULL) {
+              if (sel && !sel(ent))
+                continue;
+              p = (struct dirent*)malloc(ent->d_reclen);
+              if (p == NULL) {
+                while (--n >= 0) {
+                  free(list[n]);
+                }
+                free(list);
+                list = NULL;
+              }
+              else {
+                memcpy((void*)p, (void*)ent, ent->d_reclen);
+                list[n++] = p;
+              }
+            }
+            sync_tebako_dstable::get_tebako_dstable().closedir(reinterpret_cast<uintptr_t>(dirp));
+            if (list == NULL) {
+              TEBAKO_SET_LAST_ERROR(ENOMEM);
+            }
+            else {
+              *namelist = (struct dirent**)realloc((void*)list, std::max(n, 1) * sizeof(struct dirent*));
+              if (*namelist == NULL) {
+                *namelist = list;
+              }
+              if (compar && n > 0) {
+                qsort((void*)*namelist, n, sizeof(dirent*), (qsort_compar)compar);
+              }
+              ret = n;
+            }
+          }
+        }
+      }
+      else {
+        // This is not POSIX but posix does not cover this case (namelist==NULL)
+        // at all
+        TEBAKO_SET_LAST_ERROR(EFAULT);
+      }
+    }
+  }
+  return ret;
+}
+#endif

--- a/src/file-ctl.cpp
+++ b/src/file-ctl.cpp
@@ -1,0 +1,220 @@
+/**
+ *
+ *  Copyright (c) 2021-2025, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ * This file is a part of the Tebako project. (libdwarfs-wr)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <tebako-pch.h>
+#include <tebako-pch-pp.h>
+#include <tebako/fs/common.h>
+#include <tebako/fs/dirent.h>
+#include <tebako/fs/io.h>
+#include <tebako-io-inner.h>
+#include <tebako/fs/ruby/io_rb_w32_inner.h>
+#include <tebako-io-root.h>
+
+using namespace tebako;
+
+int tebako_access(const char* path, int amode)
+{
+  int ret = -1;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    std::string lnk;
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+      ret = dwarfs_access(p_path, amode, getuid(), getgid(), lnk);
+      if (ret == DWARFS_S_LINK_OUTSIDE) {
+        ret = TO_RB_W32(access)(lnk.c_str(), amode);
+      }
+    }
+    else {
+      ret = TO_RB_W32(access)(path, amode);
+    }
+  }
+  return ret;
+}
+
+#if defined(TEBAKO_HAS_EACCESS)
+int tebako_eaccess(const char* path, int amode)
+{
+  int ret = -1;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    std::string lnk;
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+      ret = dwarfs_access(p_path, amode, geteuid(), getegid(), lnk);
+      if (ret == DWARFS_S_LINK_OUTSIDE) {
+        ret = TO_RB_W32(eaccess)(lnk.c_str(), amode);
+      }
+    }
+    else {
+      ret = TO_RB_W32(eaccess)(path, amode);
+    }
+  }
+  return ret;
+}
+#endif
+
+#if defined(TEBAKO_HAS_LSTAT) || defined(RB_W32)
+int tebako_lstat(const char* path, struct STAT_TYPE* buf)
+{
+  int ret = -1;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    std::string r_path;
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+#ifdef _WIN32
+      struct stat _buf;
+      ret = dwarfs_lstat(p_path, &_buf, r_path);
+      buf << _buf;
+#else
+      ret = dwarfs_lstat(p_path, buf, r_path);
+#endif
+      if (ret == DWARFS_S_LINK_OUTSIDE) {
+        ret = TO_RB_W32_I128(lstat)(r_path.c_str(), buf);
+      }
+    }
+    else {
+      ret = TO_RB_W32_I128(lstat)(path, buf);
+    }
+  }
+  return ret;
+}
+#endif
+
+ssize_t tebako_readlink(const char* path, char* buf, size_t bufsize)
+{
+  ssize_t ret = -1;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+      std::string link;
+      std::string lnk;
+
+      ret = dwarfs_readlink(p_path, link, lnk);
+      if (ret >= 0) {
+        strncpy(buf, link.c_str(), bufsize);
+        ret = std::min(link.length(), bufsize);
+      }
+      else if (ret == DWARFS_S_LINK_OUTSIDE) {
+        ret = ::readlink(lnk.c_str(), buf, bufsize);
+      }
+    }
+    else {
+      ret = ::readlink(path, buf, bufsize);
+    }
+  }
+  return ret;
+}
+
+int tebako_stat(const char* path, struct STAT_TYPE* buf)
+{
+  int ret = -1;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    std::string lnk;
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+#ifdef RB_W32
+      struct stat _buf;
+      ret = dwarfs_stat(p_path, &_buf, lnk, true);
+      buf << _buf;
+#else
+      ret = dwarfs_stat(p_path, buf, lnk, true);
+#endif
+      if (ret == DWARFS_S_LINK_OUTSIDE)
+        ret = TO_RB_W32_I128(stat)(lnk.c_str(), buf);
+    }
+    else {
+      ret = TO_RB_W32_I128(stat)(path, buf);
+    }
+  }
+  return ret;
+}
+
+#ifdef TEBAKO_HAS_GETATTRLIST
+int tebako_getattrlist(const char* path,
+                       struct attrlist* attrList,
+                       void* attrBuf,
+                       size_t attrBufSize,
+                       unsigned long options)
+{
+  int ret = DWARFS_IO_ERROR;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(EFAULT);
+  }
+  else {
+    tebako_path_t t_path;
+    const char* p_path = to_tebako_path(t_path, path);
+    if (p_path) {
+      TEBAKO_SET_LAST_ERROR(ENOTSUP);
+    }
+    else {
+      ret = ::getattrlist(path, attrList, attrBuf, attrBufSize, options);
+    }
+  }
+  return ret;
+}
+#endif
+
+int within_tebako_memfs(const char* path)
+{
+  return is_tebako_path(path) ? -1 : 0;
+}
+
+int tebako_file_load_ok(const char* path)
+{
+  int ret = 0;
+
+  if (within_tebako_memfs(path)) {
+    int fd = tebako_open(2, path, O_RDONLY);
+    if (fd != -1) {
+      struct STAT_TYPE st;
+      ret = (tebako_fstat(fd, &st) == 0) ? -1 : 0;
+      tebako_close(fd);
+    }
+  }
+  return ret;
+}

--- a/src/file-io.cpp
+++ b/src/file-io.cpp
@@ -1,0 +1,263 @@
+/**
+ *
+ * Copyright (c) 2021-2025, [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ * This file is a part of the Tebako project. (libdwarfs-wr)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <tebako-pch.h>
+#include <tebako-pch-pp.h>
+#include <tebako/fs/common.h>
+#include <tebako/fs/dirent.h>
+#include <tebako/fs/io.h>
+#include <tebako-io-inner.h>
+#include <tebako/fs/ruby/io_rb_w32_inner.h>
+#include <tebako-io-root.h>
+#include <tebako/fs/internal/fd_table.h>
+
+using namespace tebako;
+
+int tebako_open(int nargs, const char* path, int flags, ...)
+{
+  int ret = -1;
+  if (path == NULL) {
+    TEBAKO_SET_LAST_ERROR(ENOENT);
+  }
+  else {
+    tebako_path_t t_path;
+    std::string r_path = path;
+    const char* p_path = to_tebako_path(t_path, path);
+
+    if (p_path) {
+      // This call will change r_path value if it is a link inside memfs
+      // pointing outside of memfs
+      ret = sync_tebako_fdtable::get_tebako_fdtable().open(p_path, flags, r_path);
+    }
+    if (!p_path || ret == DWARFS_S_LINK_OUTSIDE) {
+      if (nargs == 2) {
+        ret = TO_RB_W32_U(open)(r_path.c_str(), flags);
+      }
+      else {
+        va_list args;
+        mode_t mode;
+        va_start(args, flags);
+        // https://stackoverflow.com/questions/28054194/char-type-in-va-arg
+        // second argument to 'va_arg' is of promotable type 'mode_t' (aka
+        // 'unsigned short'); this va_arg has undefined behavior because
+        // arguments will be promoted to 'int'
+        mode = (mode_t)va_arg(args, int);
+        va_end(args);
+        ret = TO_RB_W32_U(open)(r_path.c_str(), flags, mode);
+      }
+    }
+  }
+  return ret;
+}
+
+#ifdef TEBAKO_HAS_OPENAT
+int tebako_openat(int nargs, int vfd, const char* path, int flags, ...)
+{
+  int ret = -1;
+  va_list args;
+  mode_t mode;
+  //	The openat() function shall be equivalent to the open() function except
+  // in the case where path specifies a relative path.
+  //  In this case the file to be opened is determined relative to the directory
+  //  associated with the file descriptor fd instead of the current working
+  //  directory.
+  //  ...
+  //	If openat() is passed the special value AT_FDCWD in the fd parameter,
+  // the current working directory shall be used and the behavior shall be
+  // identical to a call to open().
+  try {
+    std::string r_path;
+    std::filesystem::path std_path(path);
+    if (std_path.is_relative() && vfd != AT_FDCWD) {
+      ret = sync_tebako_fdtable::get_tebako_fdtable().openat(vfd, path, flags, r_path);
+      switch (ret) {
+        case DWARFS_INVALID_FD:
+          if (nargs == 3) {
+            ret = ::openat(vfd, path, flags);
+          }
+          else {
+            va_start(args, flags);
+            mode = (mode_t)va_arg(args, int);
+            va_end(args);
+            ret = ::openat(vfd, path, flags, mode);
+          }
+          break;
+        case DWARFS_S_LINK_OUTSIDE:
+          ret = TO_RB_W32_U(openat)(vfd, r_path.c_str(), flags);
+          break;
+        default:
+          break;
+      }
+    }
+    else {
+      if (nargs == 3) {
+        ret = tebako_open(2, path, flags);
+      }
+      else {
+        va_start(args, flags);
+        mode = (mode_t)va_arg(args, int);
+        va_end(args);
+        ret = tebako_open(3, path, flags, mode);
+      }
+    }
+  }
+  catch (...) {
+    ret = -1;
+    TEBAKO_SET_LAST_ERROR(ENOMEM);
+  }
+  return ret;
+}
+#endif
+
+off_t tebako_lseek(int vfd, off_t offset, int whence)
+{
+  off_t ret = sync_tebako_fdtable::get_tebako_fdtable().lseek(vfd, offset, whence);
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? TO_RB_W32(lseek)(vfd, offset, whence) : DWARFS_IO_ERROR;
+  }
+  return ret;
+}
+
+ssize_t tebako_read(int vfd, void* buf, size_t nbyte)
+{
+  ssize_t ret = sync_tebako_fdtable::get_tebako_fdtable().read(vfd, buf, nbyte);
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? TO_RB_W32(read)(vfd, buf, nbyte) : DWARFS_IO_ERROR;
+  }
+  return ret;
+}
+
+#ifdef TEBAKO_HAS_READV
+ssize_t tebako_readv(int vfd, const struct ::iovec* iov, int iovcnt)
+{
+  ssize_t ret = sync_tebako_fdtable::get_tebako_fdtable().readv(vfd, iov, iovcnt);
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? ::readv(vfd, iov, iovcnt) : DWARFS_IO_ERROR;
+  }
+  return ret;
+}
+#endif
+
+#if defined(TEBAKO_HAS_PREAD) || defined(RB_W32)
+ssize_t tebako_pread(int vfd, void* buf, size_t nbyte, off_t offset)
+{
+  ssize_t ret = sync_tebako_fdtable::get_tebako_fdtable().pread(vfd, buf, nbyte, offset);
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? TO_RB_W32(pread)(vfd, buf, nbyte, offset) : DWARFS_IO_ERROR;
+  }
+  return ret;
+}
+#endif
+
+int tebako_close(int vfd)
+{
+  int ret = sync_tebako_fdtable::get_tebako_fdtable().close(vfd);
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? TO_RB_W32(close)(vfd) : DWARFS_IO_ERROR;
+  }
+  return ret;
+}
+
+int tebako_fstat(int vfd, struct STAT_TYPE* buf)
+{
+#if defined(RB_W32)
+  struct stat _buf;
+  int ret = sync_tebako_fdtable::get_tebako_fdtable().fstat(vfd, &_buf);
+  buf << _buf;
+#else
+  int ret = sync_tebako_fdtable::get_tebako_fdtable().fstat(vfd, buf);
+#endif
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? TO_RB_W32_I128(fstat)(vfd, buf) : DWARFS_IO_ERROR;
+  }
+  return ret;
+}
+
+#ifdef TEBAKO_HAS_FSTATAT
+int tebako_fstatat(int vfd, const char* path, struct stat* st, int flag)
+{
+  int ret = -1;
+  try {
+    std::filesystem::path std_path(path);
+    if (std_path.is_absolute() || vfd == AT_FDCWD) {
+      ret = (flag & AT_SYMLINK_NOFOLLOW) ? tebako_lstat(path, st) : tebako_stat(path, st);
+    }
+    else {
+      std::string r_path;
+      ret = sync_tebako_fdtable::get_tebako_fdtable().fstatat(vfd, path, st, r_path, (flag & AT_SYMLINK_NOFOLLOW) == 0);
+      switch (ret) {
+        case DWARFS_INVALID_FD:
+          ret = is_valid_system_file_descriptor(vfd) ? ::fstatat(vfd, path, st, flag) : DWARFS_IO_ERROR;
+          break;
+        case DWARFS_S_LINK_OUTSIDE:
+          ret = tebako_stat(r_path.c_str(), st);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+  catch (...) {
+    ret = -1;
+    TEBAKO_SET_LAST_ERROR(ENOMEM);
+  }
+  return ret;
+}
+#endif
+
+#ifdef TEBAKO_HAS_FGETATTRLIST
+int tebako_fgetattrlist(int vfd, struct attrlist* attrList, void* attrBuf, size_t attrBufSize, unsigned long options)
+{
+  struct stat stfd;
+  int ret = sync_tebako_fdtable::get_tebako_fdtable().fstat(vfd, &stfd);
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? ::fgetattrlist(vfd, attrList, attrBuf, attrBufSize, options)
+                                               : DWARFS_IO_ERROR;
+  }
+  else {
+    ret = -1;
+    TEBAKO_SET_LAST_ERROR(ENOTSUP);
+  }
+  return ret;
+}
+#endif
+
+int tebako_flock(int vfd, int operation)
+{
+  int ret = sync_tebako_fdtable::get_tebako_fdtable().flock(vfd, operation);
+  if (ret == DWARFS_INVALID_FD) {
+    ret = is_valid_system_file_descriptor(vfd) ? ::flock(vfd, operation) : DWARFS_IO_ERROR;
+  }
+  return ret;
+}
+
+int is_tebako_file_descriptor(int vfd)
+{
+  return sync_tebako_fdtable::get_tebako_fdtable().is_valid_file_descriptor(vfd) ? -1 : 0;
+}

--- a/tests/test_c_api.cpp
+++ b/tests/test_c_api.cpp
@@ -112,13 +112,13 @@ class CApiTest : public ::testing::Test {
 
   std::string read_file_via_api(const std::string& path)
   {
-    int fd = tebako_open(path.c_str(), O_RDONLY);
+    int fd = tebako_fs_open(path.c_str(), O_RDONLY);
     if (fd < 0)
       return "";
 
     std::vector<char> buffer(4096);
-    ssize_t n = tebako_read(fd, buffer.data(), buffer.size());
-    tebako_close(fd);
+    ssize_t n = tebako_fs_read(fd, buffer.data(), buffer.size());
+    tebako_fs_close(fd);
 
     if (n <= 0)
       return "";
@@ -186,7 +186,7 @@ TEST_F(CApiTest, OperationsFailAfterUnmount)
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
   tebako_fs_unmount();
 
-  EXPECT_EQ(-1, tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY));
+  EXPECT_EQ(-1, tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY));
   EXPECT_EQ(ENODEV, tebako_get_errno());
 }
 
@@ -290,19 +290,19 @@ TEST_F(CApiTest, Open_ValidFile)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   EXPECT_GT(fd, 0);
   EXPECT_TRUE(tebako_fd_is_embedded(fd));
   EXPECT_EQ(0, tebako_get_errno());
 
-  EXPECT_EQ(0, tebako_close(fd));
+  EXPECT_EQ(0, tebako_fs_close(fd));
 }
 
 TEST_F(CApiTest, Open_NonexistentFile)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/nonexistent.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/nonexistent.txt").c_str(), O_RDONLY);
   EXPECT_EQ(-1, fd);
   EXPECT_EQ(ENOENT, tebako_get_errno());
 }
@@ -311,7 +311,7 @@ TEST_F(CApiTest, Open_NullPath)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open(nullptr, O_RDONLY);
+  int fd = tebako_fs_open(nullptr, O_RDONLY);
   EXPECT_EQ(-1, fd);
   EXPECT_EQ(EINVAL, tebako_get_errno());
 }
@@ -320,7 +320,7 @@ TEST_F(CApiTest, Open_WriteMode_Fails)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_WRONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_WRONLY);
   EXPECT_EQ(-1, fd);
   EXPECT_EQ(EROFS, tebako_get_errno());
 }
@@ -329,35 +329,35 @@ TEST_F(CApiTest, Read_Success)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
   char buffer[100] = {0};
-  ssize_t n = tebako_read(fd, buffer, sizeof(buffer));
+  ssize_t n = tebako_fs_read(fd, buffer, sizeof(buffer));
   EXPECT_GT(n, 0);
   EXPECT_STREQ("Hello, World!", buffer);
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, Read_EmptyFile)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/empty.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/empty.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
   char buffer[10];
-  ssize_t n = tebako_read(fd, buffer, sizeof(buffer));
+  ssize_t n = tebako_fs_read(fd, buffer, sizeof(buffer));
   EXPECT_EQ(0, n);  // EOF immediately
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, Read_InvalidFd)
 {
   char buffer[10];
-  ssize_t n = tebako_read(999, buffer, sizeof(buffer));
+  ssize_t n = tebako_fs_read(999, buffer, sizeof(buffer));
   EXPECT_EQ(-1, n);
   EXPECT_EQ(EBADF, tebako_get_errno());
 }
@@ -366,76 +366,76 @@ TEST_F(CApiTest, Read_NullBuffer)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
-  ssize_t n = tebako_read(fd, nullptr, 10);
+  ssize_t n = tebako_fs_read(fd, nullptr, 10);
   EXPECT_EQ(-1, n);
   EXPECT_EQ(EINVAL, tebako_get_errno());
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, Lseek_SeekSet)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
   // Seek to position 7
-  off_t pos = tebako_lseek(fd, 7, SEEK_SET);
+  off_t pos = tebako_fs_lseek(fd, 7, SEEK_SET);
   EXPECT_EQ(7, pos);
 
   // Read from new position
   char buffer[10] = {0};
-  ssize_t n = tebako_read(fd, buffer, 5);
+  ssize_t n = tebako_fs_read(fd, buffer, 5);
   EXPECT_EQ(5, n);
   EXPECT_STREQ("World", buffer);
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, Lseek_SeekCur)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
   // Read 5 bytes
   char buffer[5];
-  tebako_read(fd, buffer, 5);
+  tebako_fs_read(fd, buffer, 5);
 
   // Seek forward 2 bytes from current
-  off_t pos = tebako_lseek(fd, 2, SEEK_CUR);
+  off_t pos = tebako_fs_lseek(fd, 2, SEEK_CUR);
   EXPECT_EQ(7, pos);
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, Lseek_SeekEnd)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
   // Seek to end
-  off_t size = tebako_lseek(fd, 0, SEEK_END);
+  off_t size = tebako_fs_lseek(fd, 0, SEEK_END);
   EXPECT_EQ(13, size);  // strlen("Hello, World!")
 
   // Try to read (should get EOF)
   char buffer[10];
-  ssize_t n = tebako_read(fd, buffer, sizeof(buffer));
+  ssize_t n = tebako_fs_read(fd, buffer, sizeof(buffer));
   EXPECT_EQ(0, n);
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, Lseek_InvalidFd)
 {
-  off_t pos = tebako_lseek(999, 0, SEEK_SET);
+  off_t pos = tebako_fs_lseek(999, 0, SEEK_SET);
   EXPECT_EQ(-1, pos);
   EXPECT_EQ(EBADF, tebako_get_errno());
 }
@@ -444,20 +444,20 @@ TEST_F(CApiTest, Close_Success)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
-  EXPECT_EQ(0, tebako_close(fd));
+  EXPECT_EQ(0, tebako_fs_close(fd));
 
   // Further operations should fail
   char buffer[10];
-  EXPECT_EQ(-1, tebako_read(fd, buffer, sizeof(buffer)));
+  EXPECT_EQ(-1, tebako_fs_read(fd, buffer, sizeof(buffer)));
   EXPECT_EQ(EBADF, tebako_get_errno());
 }
 
 TEST_F(CApiTest, Close_InvalidFd)
 {
-  EXPECT_EQ(-1, tebako_close(999));
+  EXPECT_EQ(-1, tebako_fs_close(999));
   EXPECT_EQ(EBADF, tebako_get_errno());
 }
 
@@ -465,8 +465,8 @@ TEST_F(CApiTest, MultipleFds_Independent)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd1 = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
-  int fd2 = tebako_open((mount_point + "/content/data.bin").c_str(), O_RDONLY);
+  int fd1 = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd2 = tebako_fs_open((mount_point + "/content/data.bin").c_str(), O_RDONLY);
 
   ASSERT_GT(fd1, 0);
   ASSERT_GT(fd2, 0);
@@ -474,11 +474,11 @@ TEST_F(CApiTest, MultipleFds_Independent)
 
   // Both should work independently
   char buf1[10], buf2[10];
-  EXPECT_GT(tebako_read(fd1, buf1, sizeof(buf1)), 0);
-  EXPECT_GT(tebako_read(fd2, buf2, sizeof(buf2)), 0);
+  EXPECT_GT(tebako_fs_read(fd1, buf1, sizeof(buf1)), 0);
+  EXPECT_GT(tebako_fs_read(fd2, buf2, sizeof(buf2)), 0);
 
-  tebako_close(fd1);
-  tebako_close(fd2);
+  tebako_fs_close(fd1);
+  tebako_fs_close(fd2);
 }
 
 // ============================================================
@@ -489,18 +489,18 @@ TEST_F(CApiTest, Opendir_Success)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir = tebako_opendir((mount_point + "/content").c_str());
+  tebako_dir_t dir = tebako_fs_opendir((mount_point + "/content").c_str());
   ASSERT_NE(nullptr, dir);
   EXPECT_EQ(0, tebako_get_errno());
 
-  EXPECT_EQ(0, tebako_closedir(dir));
+  EXPECT_EQ(0, tebako_fs_closedir(dir));
 }
 
 TEST_F(CApiTest, Opendir_Nonexistent)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir = tebako_opendir((mount_point + "/nonexistent").c_str());
+  tebako_dir_t dir = tebako_fs_opendir((mount_point + "/nonexistent").c_str());
   EXPECT_EQ(nullptr, dir);
   EXPECT_EQ(ENOENT, tebako_get_errno());
 }
@@ -509,7 +509,7 @@ TEST_F(CApiTest, Opendir_NullPath)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir = tebako_opendir(nullptr);
+  tebako_dir_t dir = tebako_fs_opendir(nullptr);
   EXPECT_EQ(nullptr, dir);
   EXPECT_EQ(EINVAL, tebako_get_errno());
 }
@@ -518,12 +518,12 @@ TEST_F(CApiTest, Readdir_ListFiles)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir = tebako_opendir((mount_point + "/content").c_str());
+  tebako_dir_t dir = tebako_fs_opendir((mount_point + "/content").c_str());
   ASSERT_NE(nullptr, dir);
 
   std::vector<std::string> entries;
   struct tebako_c_dirent* entry;
-  while ((entry = tebako_readdir(dir)) != nullptr) {
+  while ((entry = tebako_fs_readdir(dir)) != nullptr) {
     entries.push_back(entry->d_name);
   }
 
@@ -537,21 +537,21 @@ TEST_F(CApiTest, Readdir_ListFiles)
 
   EXPECT_TRUE(has_hello || has_data || has_subdir) << "Expected test files not found";
 
-  tebako_closedir(dir);
+  tebako_fs_closedir(dir);
 }
 
 TEST_F(CApiTest, Readdir_CheckTypes)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir = tebako_opendir((mount_point + "/content").c_str());
+  tebako_dir_t dir = tebako_fs_opendir((mount_point + "/content").c_str());
   ASSERT_NE(nullptr, dir);
 
   bool found_file = false;
   bool found_dir = false;
 
   struct tebako_c_dirent* entry;
-  while ((entry = tebako_readdir(dir)) != nullptr) {
+  while ((entry = tebako_fs_readdir(dir)) != nullptr) {
     if (entry->d_type == DT_REG)
       found_file = true;
     if (entry->d_type == DT_DIR)
@@ -560,29 +560,29 @@ TEST_F(CApiTest, Readdir_CheckTypes)
 
   EXPECT_TRUE(found_file) << "Should find at least one regular file";
 
-  tebako_closedir(dir);
+  tebako_fs_closedir(dir);
 }
 
 TEST_F(CApiTest, Readdir_EmptyAtEnd)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir = tebako_opendir((mount_point + "/content").c_str());
+  tebako_dir_t dir = tebako_fs_opendir((mount_point + "/content").c_str());
   ASSERT_NE(nullptr, dir);
 
   // Read all entries
-  while (tebako_readdir(dir) != nullptr) {
+  while (tebako_fs_readdir(dir) != nullptr) {
   }
 
   // Next call should return nullptr
-  EXPECT_EQ(nullptr, tebako_readdir(dir));
+  EXPECT_EQ(nullptr, tebako_fs_readdir(dir));
 
-  tebako_closedir(dir);
+  tebako_fs_closedir(dir);
 }
 
 TEST_F(CApiTest, Readdir_InvalidHandle)
 {
-  struct tebako_c_dirent* entry = tebako_readdir(nullptr);
+  struct tebako_c_dirent* entry = tebako_fs_readdir(nullptr);
   EXPECT_EQ(nullptr, entry);
   EXPECT_EQ(EBADF, tebako_get_errno());
 }
@@ -591,16 +591,16 @@ TEST_F(CApiTest, Closedir_Success)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir = tebako_opendir((mount_point + "/content").c_str());
+  tebako_dir_t dir = tebako_fs_opendir((mount_point + "/content").c_str());
   ASSERT_NE(nullptr, dir);
 
-  EXPECT_EQ(0, tebako_closedir(dir));
+  EXPECT_EQ(0, tebako_fs_closedir(dir));
   EXPECT_EQ(0, tebako_get_errno());
 }
 
 TEST_F(CApiTest, Closedir_InvalidHandle)
 {
-  EXPECT_EQ(-1, tebako_closedir(nullptr));
+  EXPECT_EQ(-1, tebako_fs_closedir(nullptr));
   EXPECT_EQ(EBADF, tebako_get_errno());
 }
 
@@ -608,18 +608,18 @@ TEST_F(CApiTest, MultipleDirs_Independent)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  tebako_dir_t dir1 = tebako_opendir((mount_point + "/content").c_str());
-  tebako_dir_t dir2 = tebako_opendir((mount_point + "/content/subdir").c_str());
+  tebako_dir_t dir1 = tebako_fs_opendir((mount_point + "/content").c_str());
+  tebako_dir_t dir2 = tebako_fs_opendir((mount_point + "/content/subdir").c_str());
 
   ASSERT_NE(nullptr, dir1);
   ASSERT_NE(nullptr, dir2);
   EXPECT_NE(dir1, dir2);
 
   // Both should work
-  EXPECT_NE(nullptr, tebako_readdir(dir1));
+  EXPECT_NE(nullptr, tebako_fs_readdir(dir1));
 
-  tebako_closedir(dir1);
-  tebako_closedir(dir2);
+  tebako_fs_closedir(dir1);
+  tebako_fs_closedir(dir2);
 }
 
 // ============================================================
@@ -631,7 +631,7 @@ TEST_F(CApiTest, Stat_RegularFile)
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
   struct stat st;
-  int result = tebako_stat((mount_point + "/content/hello.txt").c_str(), &st);
+  int result = tebako_fs_stat((mount_point + "/content/hello.txt").c_str(), &st);
 
   EXPECT_EQ(0, result);
   EXPECT_TRUE(S_ISREG(st.st_mode));
@@ -643,7 +643,7 @@ TEST_F(CApiTest, Stat_Directory)
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
   struct stat st;
-  int result = tebako_stat((mount_point + "/content/subdir").c_str(), &st);
+  int result = tebako_fs_stat((mount_point + "/content/subdir").c_str(), &st);
 
   EXPECT_EQ(0, result);
   EXPECT_TRUE(S_ISDIR(st.st_mode));
@@ -654,7 +654,7 @@ TEST_F(CApiTest, Stat_Nonexistent)
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
   struct stat st;
-  int result = tebako_stat((mount_point + "/nonexistent").c_str(), &st);
+  int result = tebako_fs_stat((mount_point + "/nonexistent").c_str(), &st);
 
   EXPECT_EQ(-1, result);
   EXPECT_EQ(ENOENT, tebako_get_errno());
@@ -665,10 +665,10 @@ TEST_F(CApiTest, Stat_NullArguments)
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
   struct stat st;
-  EXPECT_EQ(-1, tebako_stat(nullptr, &st));
+  EXPECT_EQ(-1, tebako_fs_stat(nullptr, &st));
   EXPECT_EQ(EINVAL, tebako_get_errno());
 
-  EXPECT_EQ(-1, tebako_stat((mount_point + "/content/hello.txt").c_str(), nullptr));
+  EXPECT_EQ(-1, tebako_fs_stat((mount_point + "/content/hello.txt").c_str(), nullptr));
   EXPECT_EQ(EINVAL, tebako_get_errno());
 }
 
@@ -676,21 +676,21 @@ TEST_F(CApiTest, Fstat_Success)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
   struct stat st;
-  EXPECT_EQ(0, tebako_fstat(fd, &st));
+  EXPECT_EQ(0, tebako_fs_fstat(fd, &st));
   EXPECT_TRUE(S_ISREG(st.st_mode));
   EXPECT_EQ(13, st.st_size);
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, Fstat_InvalidFd)
 {
   struct stat st;
-  EXPECT_EQ(-1, tebako_fstat(999, &st));
+  EXPECT_EQ(-1, tebako_fs_fstat(999, &st));
   EXPECT_EQ(EBADF, tebako_get_errno());
 }
 
@@ -698,13 +698,13 @@ TEST_F(CApiTest, Fstat_NullStat)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
-  EXPECT_EQ(-1, tebako_fstat(fd, nullptr));
+  EXPECT_EQ(-1, tebako_fs_fstat(fd, nullptr));
   EXPECT_EQ(EINVAL, tebako_get_errno());
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 // ============================================================
@@ -743,14 +743,14 @@ TEST_F(CApiTest, FdIsEmbedded_ValidFd)
 {
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
 
-  int fd = tebako_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
+  int fd = tebako_fs_open((mount_point + "/content/hello.txt").c_str(), O_RDONLY);
   ASSERT_GT(fd, 0);
 
   EXPECT_EQ(1, tebako_fd_is_embedded(fd));
   EXPECT_EQ(0, tebako_fd_is_embedded(STDOUT_FILENO));
   EXPECT_EQ(0, tebako_fd_is_embedded(STDIN_FILENO));
 
-  tebako_close(fd);
+  tebako_fs_close(fd);
 }
 
 TEST_F(CApiTest, FdIsEmbedded_FlagCheck)
@@ -770,12 +770,12 @@ TEST_F(CApiTest, FdIsEmbedded_FlagCheck)
 TEST_F(CApiTest, GetErrno_ThreadLocal)
 {
   // Set an error
-  tebako_open(nullptr, O_RDONLY);  // Will set EINVAL
+  tebako_fs_open(nullptr, O_RDONLY);  // Will set EINVAL
   EXPECT_EQ(EINVAL, tebako_get_errno());
 
   // Different operation sets different error
   ASSERT_EQ(0, tebako_fs_init_from_file(archive_path.c_str(), mount_point.c_str()));
-  tebako_open((mount_point + "/nonexistent").c_str(), O_RDONLY);
+  tebako_fs_open((mount_point + "/nonexistent").c_str(), O_RDONLY);
   EXPECT_EQ(ENOENT, tebako_get_errno());
 }
 
@@ -848,31 +848,31 @@ TEST_F(CApiTest, Integration_FullWorkflow)
   EXPECT_EQ(1, tebako_path_is_embedded((mount_point + "/content").c_str()));
 
   // List directory
-  tebako_dir_t dir = tebako_opendir((mount_point + "/content").c_str());
+  tebako_dir_t dir = tebako_fs_opendir((mount_point + "/content").c_str());
   ASSERT_NE(nullptr, dir);
 
   int file_count = 0;
   struct tebako_c_dirent* entry;
-  while ((entry = tebako_readdir(dir)) != nullptr) {
+  while ((entry = tebako_fs_readdir(dir)) != nullptr) {
     file_count++;
 
     // Stat each entry
     std::string full_path = mount_point + "/content/" + entry->d_name;
     struct stat st;
-    EXPECT_EQ(0, tebako_stat(full_path.c_str(), &st));
+    EXPECT_EQ(0, tebako_fs_stat(full_path.c_str(), &st));
 
     // If regular file, try opening
     if (entry->d_type == DT_REG) {
-      int fd = tebako_open(full_path.c_str(), O_RDONLY);
+      int fd = tebako_fs_open(full_path.c_str(), O_RDONLY);
       EXPECT_GT(fd, 0);
       if (fd > 0) {
-        tebako_close(fd);
+        tebako_fs_close(fd);
       }
     }
   }
 
   EXPECT_GT(file_count, 0);
-  tebako_closedir(dir);
+  tebako_fs_closedir(dir);
 
   // Unmount
   tebako_fs_unmount();

--- a/tests/test_extraction.cpp
+++ b/tests/test_extraction.cpp
@@ -353,7 +353,7 @@ TEST_F(ExtractionTest, Metadata_ModificationTimePreserved)
 
   // Get original mtime from archive
   struct stat st;
-  ASSERT_EQ(0, tebako_stat((mount_point + "/content/root.txt").c_str(), &st));
+  ASSERT_EQ(0, tebako_fs_stat((mount_point + "/content/root.txt").c_str(), &st));
   time_t original_mtime = st.st_mtime;
 
   ASSERT_EQ(0, tebako_fs_extract_all(extract_dir.c_str()));
@@ -454,13 +454,13 @@ TEST_F(ExtractionTest, Integration_ExtractAndCompare)
 
   for (const auto& rel_path : test_files) {
     // Read from VFS
-    int fd = tebako_open((mount_point + rel_path).c_str(), O_RDONLY);
+    int fd = tebako_fs_open((mount_point + rel_path).c_str(), O_RDONLY);
     ASSERT_GT(fd, 0) << "Failed to open: " << rel_path;
 
     std::vector<char> vfs_content(20000);
-    ssize_t vfs_size = tebako_read(fd, vfs_content.data(), vfs_content.size());
+    ssize_t vfs_size = tebako_fs_read(fd, vfs_content.data(), vfs_content.size());
     ASSERT_GE(vfs_size, 0);
-    tebako_close(fd);
+    tebako_fs_close(fd);
 
     // Read from disk
     std::string disk_path = extract_dir + rel_path;


### PR DESCRIPTION
## Summary

Restores the legacy tebako POSIX-shim quartet — `src/file-ctl.cpp`, `src/file-io.cpp`, `src/dir-ctl.cpp`, `src/dir-io.cpp` — from libdwarfs-wr v0.11.0 lineage (`2acee8f^`), deleted by the stage-1 rewrite (`2acee8f`). These implement the legacy `tebako_*` libc surface declared by the shipped `include/tebako/tebako-io.h`, which tebako's pass1 patches macro-rename ruby's libc calls to.

**Restored surface (POSIX):** is_tebako_file_descriptor, tebako_access, tebako_chdir, tebako_dirfd, tebako_fdopendir, tebako_fgetattrlist, tebako_file_load_ok, tebako_flock, tebako_fstatat, tebako_getattrlist, tebako_getcwd, tebako_lstat, tebako_mkdir, tebako_openat, tebako_pread, tebako_readlink, tebako_readv, tebako_rmdir, tebako_scandir, tebako_seekdir, tebako_telldir, tebako_unlink, within_tebako_memfs — plus the legacy (variadic) `tebako_open`, `tebako_lseek`, `tebako_read`, `tebako_close`, `tebako_fstat`, `tebako_stat`, `tebako_opendir`, `tebako_readdir`, `tebako_closedir`.

`tebako_eaccess` remains conditional on `TEBAKO_HAS_EACCESS` (absent on macOS — the macOS SDK has no `eaccess()`; identical guard and behavior as v0.11.0). `is_tebako_path_w` is RB_W32-only (N/A on POSIX).

## Adaptations vs the historical files (minimal, no redesign)

- **Includes → `tebako/fs/*` mirrors.** The rewrite carries byte-identical mirrors of the legacy headers (`tebako/fs/common.h`, `tebako/fs/dirent.h`, `tebako/fs/io.h`, `tebako/fs/internal/fd_table.h`, `tebako/fs/internal/kfd.h`, `tebako/fs/ruby/io_rb_w32_inner.h`); surviving legacy sources already include the mirrors. Including both originals and mirrors in one TU is a redefinition error, so the quartet follows the same convention.
- **`tebako_dirent` union → buffer struct.** `dir-io.cpp`'s two entry extractions (`&e->e`) now use `static_cast<struct dirent*>(e->e())`; the mirror's accessor returns `void*`.
- **`include/tebako-pch.h`: `#include_next <dirent.h>`.** With the legacy API enabled, `include/tebako/fs` is on the include path, so `<dirent.h>` resolves to the `tebako/fs/dirent.h` shadow and the POSIX `DIR`/`struct dirent`/`scandir` declarations disappear. The pch (a legacy-layer header) now pulls the real system header as well.
- **CMake:** quartet added to the existing `WITH_LEGACY_TEBAKO_API`-gated legacy sources block, after `c_api.cpp`.

## Known name collision (deliberately NOT fixed here)

The quartet defines extern "C" `tebako_open`/`tebako_read`/`tebako_lseek`/`tebako_close`/`tebako_stat`/`tebako_fstat`/`tebako_opendir`/`tebako_readdir`/`tebako_closedir` with **legacy signatures** (e.g. variadic `tebako_open(int nargs, const char*, int, ...)`) that `src/c_api.cpp` also exports with **modern signatures** (e.g. `tebako_open(const char*, int)`). `nm build/libtfs.a | grep -c ' T _tebako_open$'` → **2**.

Measured behavior on macOS (ld64):
- **modern-only binary** (all 380 current tests): pulls `c_api.cpp.o` (archive member 9, before the quartet), quartet objects never pulled → modern bindings, green.
- **legacy-only binary**: pulls only quartet objects; internal `tebako_open(2, path, flags)` calls bind to the **legacy variadic** `tebako_open`; `c_api.cpp.o` never pulled. Links clean.
- **mixed binary** (references both modern-only and legacy-only symbols): hard duplicate-symbol link failure (`_tebako_open`, `_tebako_read`, `_tebako_lseek`, `_tebako_close`, `_tebako_fstat`, …). This is the collision the sibling modern-API-rename task resolves.

## Verification

- Canonical configure+build+`ctest` (Release, vcpkg toolchain): **380/380 tests passed**.
- Function-surface gate: 23/24 gate symbols present in `libtfs.a`; only `tebako_eaccess` absent (platform-conditional, no `eaccess` in the macOS SDK — same as v0.11.0).
- Legacy gtest files (`tests/tests-{file-io,file-ctl,dir-io,dir-ctl}.cpp`) remain unwired: their `PACKAGED_FILESYSTEM_STEP_*`/incbin fixture pipeline was removed by the rewrite; resurrecting it is out of scope (noted, not half-wired).