### PR TITLE
feat: tpkg.h tebako package manifest mini-lib (Stage 3A-1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -986,6 +986,26 @@ if (WITH_TESTS)
   )
   gtest_add_tests(TARGET test_lru_cache)
 
+  # tpkg.h tebako package manifest mini-lib tests (header-only, no tfs link)
+  add_executable(test_tpkg
+    "tests/test_tpkg.cpp"
+    "tests/test_tpkg_c99.c"
+  )
+  # The .c TU is built as strict C99 to prove the single-header library is C99-clean
+  set_target_properties(test_tpkg PROPERTIES
+    C_STANDARD 99
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+  )
+  target_include_directories(test_tpkg PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  target_link_libraries(test_tpkg PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+  )
+  gtest_add_tests(TARGET test_tpkg)
+
   # Unified interface tests
   add_executable(test_unified_interface
     "tests/test_unified_interface.cpp"

--- a/include/tebako/tpkg.h
+++ b/include/tebako/tpkg.h
@@ -1,0 +1,575 @@
+/**
+ * @file tpkg.h
+ * @brief tebako package manifest (tpkg) — single-header C99 mini-lib
+ *
+ * Copyright (c) 2026 [Ribose Inc](https://www.ribose.com).
+ * All rights reserved.
+ * This file is a part of the Tebako project (libtfs).
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ============================================================================
+ * Manifest trailer v1 — wire layout (all integers little-endian):
+ *
+ *   [payload][slot 0 .. slot n-1 records][trailer header — fixed size, at EOF]
+ *
+ *   trailer header (TPKG_HEADER_SIZE = 166 bytes):
+ *     offset  size  field
+ *        0    10    magic "TEBAKOTFS\0" (10 bytes, NUL-terminated)
+ *       10     4    u32 version (TPKG_VERSION = 1)
+ *       14     4    u32 package_flags (bit 0: TPKG_FLAG_LEAN — bootstrap+images
+ *                    only, runtime resolved at run time)
+ *       18     4    u32 slot_count (1..TPKG_MAX_SLOTS)
+ *       22     8    u64 slot_table_offset (absolute file offset of slot 0 record)
+ *       30   128    char runtime_ref[128] (UTF-8, NUL-padded; empty = classic bundle)
+ *      158     4    u32 launcher_abi
+ *      162     4    u32 header_crc32 — tpkg_crc32() over header bytes [0, 162)
+ *
+ *   slot record (TPKG_SLOT_SIZE = 280 bytes):
+ *     offset  size  field
+ *        0     8    u64 offset (image start, absolute file offset)
+ *        8     8    u64 size   (image length in bytes)
+ *       16     4    u32 format_id (0=auto(magic), 1=dwarfs, 2=squashfs, 3=zip)
+ *       20     4    u32 flags
+ *       24   256    char mount_point[256] (UTF-8, NUL-padded)
+ *
+ * Reader algorithm: read the fixed-size header at EOF - TPKG_HEADER_SIZE,
+ * check the magic, verify header_crc32, then read slot_count slot records at
+ * slot_table_offset. The table (and therefore the payload) may sit at any —
+ * including odd — file offset.
+ *
+ * Absent vs. corrupt: a file whose last-166-byte window does not start with
+ * the 4-byte prefix "TEBA" is reported as TPKG_ERR_NO_TRAILER (a classic
+ * bundle without a manifest — not an error condition per se; callers fall
+ * back to offset auto-detection). A matching prefix with a mismatching full
+ * magic is TPKG_ERR_MAGIC (corrupt trailer); a magic-valid header with a bad
+ * crc is TPKG_ERR_CRC.
+ *
+ * Error handling: all tpkg_* functions (except tpkg_crc32, tpkg_errno and
+ * tpkg_strerror) return 0 on success and -1 on failure, with a TPKG_ERR_*
+ * code available from tpkg_errno(). The error state is a process-global
+ * (ISO C99 has no portable TLS); it is reset at the entry of every public
+ * function and is NOT thread-safe.
+ *
+ * Usage: in exactly one translation unit, #define TPKG_IMPLEMENTATION before
+ * #include <tebako/tpkg.h>; every other TU includes it plain. On POSIX the
+ * implementation section defines _POSIX_C_SOURCE 200809L if it is not
+ * defined yet, so include tpkg.h before any system header in that TU.
+ * No dependencies beyond libc.
+ * ============================================================================
+ */
+
+#ifndef TEBAKO_TPKG_H
+#define TEBAKO_TPKG_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ---- format constants ---------------------------------------------------- */
+
+#define TPKG_VERSION 1u
+#define TPKG_MAX_SLOTS 8u
+#define TPKG_HEADER_SIZE 166u
+#define TPKG_SLOT_SIZE 280u
+#define TPKG_MOUNT_POINT_LEN 256u
+#define TPKG_RUNTIME_REF_LEN 128u
+#define TPKG_MAGIC "TEBAKOTFS"
+#define TPKG_MAGIC_LEN 10u        /* including the terminating NUL */
+#define TPKG_MAGIC_PREFIX_LEN 4u  /* "TEBA": absent-vs-corrupt discriminator */
+
+/* package_flags */
+#define TPKG_FLAG_LEAN 0x1u
+
+/* format_id */
+#define TPKG_FORMAT_AUTO 0u
+#define TPKG_FORMAT_DWARFS 1u
+#define TPKG_FORMAT_SQUASHFS 2u
+#define TPKG_FORMAT_ZIP 3u
+
+/* ---- error codes (returned by tpkg_errno) -------------------------------- */
+
+enum {
+  TPKG_OK = 0,             /* success */
+  TPKG_ERR_NO_TRAILER = 1, /* no manifest trailer present (absent — not an error per se) */
+  TPKG_ERR_MAGIC = 2,      /* magic prefix present but full magic mismatch (corrupt) */
+  TPKG_ERR_CRC = 3,        /* header_crc32 mismatch (corrupt) */
+  TPKG_ERR_IO = 4,         /* underlying i/o failure */
+  TPKG_ERR_BOUNDS = 5,     /* slot table outside file bounds */
+  TPKG_ERR_SLOTS = 6,      /* slot_count == 0 or > TPKG_MAX_SLOTS */
+  TPKG_ERR_INVALID = 7,    /* structural validation failure */
+  TPKG_ERR_ARG = 8,        /* invalid argument (NULL, bad fd) */
+  TPKG_ERR_VERSION = 9     /* unsupported manifest version */
+};
+
+/* ---- manifest structures -------------------------------------------------- */
+
+typedef struct tpkg_slot {
+  uint64_t offset;
+  uint64_t size;
+  uint32_t format_id;
+  uint32_t flags;
+  char mount_point[TPKG_MOUNT_POINT_LEN];
+} tpkg_slot;
+
+typedef struct tpkg_manifest {
+  uint32_t version;
+  uint32_t package_flags;
+  uint32_t slot_count;
+  uint32_t launcher_abi;
+  char runtime_ref[TPKG_RUNTIME_REF_LEN];
+  tpkg_slot slots[TPKG_MAX_SLOTS];
+} tpkg_manifest;
+
+/* ---- API ------------------------------------------------------------------ */
+
+/* Read the manifest trailer of an open binary (seeks to EOF; the file offset
+ * is left unspecified). */
+int tpkg_read_fd(int fd, tpkg_manifest* out);
+
+/* Read the manifest trailer from an in-memory image of the binary. */
+int tpkg_read_mem(const void* data, size_t size, tpkg_manifest* out);
+
+/* Append the slot table + trailer header to an open binary (at current EOF).
+ * The manifest is validated first; a rejected manifest appends nothing. */
+int tpkg_write_fd(int fd, const tpkg_manifest* m);
+
+/* Magic-independent structural checks: version supported, slot_count in
+ * 1..TPKG_MAX_SLOTS, offset+size non-overflowing, format_id <= TPKG_FORMAT_ZIP,
+ * runtime_ref and mount_points NUL-terminated within their fixed fields. */
+int tpkg_validate(const tpkg_manifest* m);
+
+/* CRC-32 (zlib polynomial 0xEDB88320, init/xorout 0xFFFFFFFF) — exposed for
+ * header_crc32 computation and verification. Pure; does not touch tpkg_errno. */
+uint32_t tpkg_crc32(const void* data, size_t n);
+
+/* Code of the last failed (or succeeded) tpkg operation on this process. */
+int tpkg_errno(void);
+
+/* Static string for a TPKG_ERR_* code (never NULL). */
+const char* tpkg_strerror(int err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TEBAKO_TPKG_H */
+
+/* ~~~~~~~~~~~~~~~~~~~~~~~~~ implementation ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ */
+
+#if defined(TPKG_IMPLEMENTATION) && !defined(TPKG_IMPLEMENTATION_DONE)
+#define TPKG_IMPLEMENTATION_DONE
+
+#include <stdio.h> /* SEEK_SET / SEEK_END */
+#include <string.h>
+
+#if defined(_WIN32)
+#include <io.h>
+typedef __int64 tpkg__off_t;
+typedef int tpkg__ssize_t;
+typedef unsigned int tpkg__io_count_t;
+#define tpkg__lseek _lseeki64
+#define tpkg__read _read
+#define tpkg__write _write
+#else
+#if !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200809L
+#endif
+#include <sys/types.h>
+#include <unistd.h>
+typedef off_t tpkg__off_t;
+typedef ssize_t tpkg__ssize_t;
+typedef size_t tpkg__io_count_t;
+#define tpkg__lseek lseek
+#define tpkg__read read
+#define tpkg__write write
+#endif
+
+/* header field offsets */
+enum {
+  TPKG__OFF_MAGIC = 0,
+  TPKG__OFF_VERSION = 10,
+  TPKG__OFF_PACKAGE_FLAGS = 14,
+  TPKG__OFF_SLOT_COUNT = 18,
+  TPKG__OFF_TABLE = 22,
+  TPKG__OFF_RUNTIME_REF = 30,
+  TPKG__OFF_LAUNCHER_ABI = 158,
+  TPKG__OFF_CRC32 = 162
+};
+
+/* slot record field offsets */
+enum {
+  TPKG__REC_OFFSET = 0,
+  TPKG__REC_SIZE = 8,
+  TPKG__REC_FORMAT = 16,
+  TPKG__REC_FLAGS = 20,
+  TPKG__REC_MOUNT = 24
+};
+
+/* wire sizes are fixed by the format; catch exotic padding at compile time */
+typedef char tpkg__assert_slot_size[(sizeof(tpkg_slot) == TPKG_SLOT_SIZE) ? 1 : -1];
+typedef char tpkg__assert_manifest_size[(sizeof(tpkg_manifest) ==
+                                         4 * sizeof(uint32_t) + TPKG_RUNTIME_REF_LEN +
+                                             TPKG_MAX_SLOTS * sizeof(tpkg_slot))
+                                            ? 1
+                                            : -1];
+
+/* ---- error state ---------------------------------------------------------- */
+
+static int tpkg__last_err = TPKG_OK;
+
+int tpkg_errno(void)
+{
+  return tpkg__last_err;
+}
+
+static int tpkg__fail(int code)
+{
+  tpkg__last_err = code;
+  return -1;
+}
+
+const char* tpkg_strerror(int err)
+{
+  switch (err) {
+    case TPKG_OK:
+      return "success";
+    case TPKG_ERR_NO_TRAILER:
+      return "no tpkg manifest trailer present";
+    case TPKG_ERR_MAGIC:
+      return "corrupt tpkg trailer magic";
+    case TPKG_ERR_CRC:
+      return "tpkg trailer header crc32 mismatch";
+    case TPKG_ERR_IO:
+      return "tpkg i/o error";
+    case TPKG_ERR_BOUNDS:
+      return "tpkg slot table out of file bounds";
+    case TPKG_ERR_SLOTS:
+      return "tpkg slot count out of range (1..TPKG_MAX_SLOTS)";
+    case TPKG_ERR_INVALID:
+      return "invalid tpkg manifest structure";
+    case TPKG_ERR_ARG:
+      return "invalid tpkg argument";
+    case TPKG_ERR_VERSION:
+      return "unsupported tpkg manifest version";
+    default:
+      return "unknown tpkg error";
+  }
+}
+
+/* ---- CRC-32 (zlib polynomial) -------------------------------------------- */
+
+uint32_t tpkg_crc32(const void* data, size_t n)
+{
+  const uint8_t* p = (const uint8_t*)data;
+  uint32_t crc = 0xFFFFFFFFu;
+  size_t i;
+  int k;
+  for (i = 0; i < n; i++) {
+    crc ^= p[i];
+    for (k = 0; k < 8; k++) {
+      crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+    }
+  }
+  return crc ^ 0xFFFFFFFFu;
+}
+
+/* ---- little-endian codec -------------------------------------------------- */
+
+static void tpkg__put32(uint8_t* p, uint32_t v)
+{
+  p[0] = (uint8_t)(v & 0xFFu);
+  p[1] = (uint8_t)((v >> 8) & 0xFFu);
+  p[2] = (uint8_t)((v >> 16) & 0xFFu);
+  p[3] = (uint8_t)((v >> 24) & 0xFFu);
+}
+
+static void tpkg__put64(uint8_t* p, uint64_t v)
+{
+  int i;
+  for (i = 0; i < 8; i++) {
+    p[i] = (uint8_t)((v >> (8 * i)) & 0xFFu);
+  }
+}
+
+static uint32_t tpkg__get32(const uint8_t* p)
+{
+  return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static uint64_t tpkg__get64(const uint8_t* p)
+{
+  uint64_t v = 0;
+  int i;
+  for (i = 0; i < 8; i++) {
+    v |= (uint64_t)p[i] << (8 * i);
+  }
+  return v;
+}
+
+/* ---- helpers -------------------------------------------------------------- */
+
+static size_t tpkg__strnlen(const char* s, size_t max)
+{
+  const char* nul = (const char*)memchr(s, '\0', max);
+  return nul ? (size_t)(nul - s) : max;
+}
+
+/* copy a C string into a fixed-width field, zero-padding the remainder;
+ * callers must have validated NUL-termination within width */
+static void tpkg__put_str(uint8_t* p, const char* s, size_t width)
+{
+  size_t len = tpkg__strnlen(s, width);
+  memcpy(p, s, len);
+  memset(p + len, 0, width - len);
+}
+
+static int tpkg__read_full(int fd, void* buf, size_t n)
+{
+  uint8_t* p = (uint8_t*)buf;
+  while (n > 0) {
+    tpkg__ssize_t r = tpkg__read(fd, p, (tpkg__io_count_t)n);
+    if (r <= 0) {
+      return -1;
+    }
+    p += (size_t)r;
+    n -= (size_t)r;
+  }
+  return 0;
+}
+
+static int tpkg__write_full(int fd, const void* buf, size_t n)
+{
+  const uint8_t* p = (const uint8_t*)buf;
+  while (n > 0) {
+    tpkg__ssize_t r = tpkg__write(fd, p, (tpkg__io_count_t)n);
+    if (r <= 0) {
+      return -1;
+    }
+    p += (size_t)r;
+    n -= (size_t)r;
+  }
+  return 0;
+}
+
+/* ---- validation ------------------------------------------------------------ */
+
+int tpkg_validate(const tpkg_manifest* m)
+{
+  uint32_t i;
+  tpkg__last_err = TPKG_OK;
+  if (m == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  if (m->version != TPKG_VERSION) {
+    return tpkg__fail(TPKG_ERR_VERSION);
+  }
+  if (m->slot_count == 0 || m->slot_count > TPKG_MAX_SLOTS) {
+    return tpkg__fail(TPKG_ERR_SLOTS);
+  }
+  if (tpkg__strnlen(m->runtime_ref, TPKG_RUNTIME_REF_LEN) == TPKG_RUNTIME_REF_LEN) {
+    return tpkg__fail(TPKG_ERR_INVALID);
+  }
+  for (i = 0; i < m->slot_count; i++) {
+    const tpkg_slot* s = &m->slots[i];
+    if (s->size > UINT64_MAX - s->offset) {
+      return tpkg__fail(TPKG_ERR_INVALID);
+    }
+    if (s->format_id > TPKG_FORMAT_ZIP) {
+      return tpkg__fail(TPKG_ERR_INVALID);
+    }
+    if (tpkg__strnlen(s->mount_point, TPKG_MOUNT_POINT_LEN) == TPKG_MOUNT_POINT_LEN) {
+      return tpkg__fail(TPKG_ERR_INVALID);
+    }
+  }
+  return 0;
+}
+
+/* ---- reader core ------------------------------------------------------------ */
+
+/* read exactly n bytes at absolute offset off (off+n guaranteed in bounds) */
+typedef int (*tpkg__readat_fn)(void* ctx, uint64_t off, void* buf, size_t n);
+
+static int tpkg__mem_readat(void* ctx, uint64_t off, void* buf, size_t n)
+{
+  memcpy(buf, (const uint8_t*)ctx + off, n);
+  return 0;
+}
+
+static int tpkg__fd_readat(void* ctx, uint64_t off, void* buf, size_t n)
+{
+  int fd = *(int*)ctx;
+  if (tpkg__lseek(fd, (tpkg__off_t)off, SEEK_SET) == (tpkg__off_t)-1) {
+    return -1;
+  }
+  return tpkg__read_full(fd, buf, n);
+}
+
+static int tpkg__read_core(tpkg__readat_fn readat, void* ctx, uint64_t size, tpkg_manifest* out)
+{
+  uint8_t hdr[TPKG_HEADER_SIZE];
+  uint8_t table[TPKG_MAX_SLOTS * TPKG_SLOT_SIZE];
+  uint64_t table_off;
+  uint64_t avail;
+  uint32_t version;
+  uint32_t slot_count;
+  uint32_t i;
+
+  if (size < TPKG_HEADER_SIZE) {
+    return tpkg__fail(TPKG_ERR_NO_TRAILER);
+  }
+  if (readat(ctx, size - TPKG_HEADER_SIZE, hdr, TPKG_HEADER_SIZE) != 0) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+
+  /* absent vs corrupt: no "TEBA" prefix -> classic bundle, no trailer */
+  if (memcmp(hdr + TPKG__OFF_MAGIC, TPKG_MAGIC, TPKG_MAGIC_PREFIX_LEN) != 0) {
+    return tpkg__fail(TPKG_ERR_NO_TRAILER);
+  }
+  if (memcmp(hdr + TPKG__OFF_MAGIC, TPKG_MAGIC, TPKG_MAGIC_LEN) != 0) {
+    return tpkg__fail(TPKG_ERR_MAGIC);
+  }
+  if (tpkg_crc32(hdr, TPKG__OFF_CRC32) != tpkg__get32(hdr + TPKG__OFF_CRC32)) {
+    return tpkg__fail(TPKG_ERR_CRC);
+  }
+
+  version = tpkg__get32(hdr + TPKG__OFF_VERSION);
+  if (version != TPKG_VERSION) {
+    return tpkg__fail(TPKG_ERR_VERSION);
+  }
+  slot_count = tpkg__get32(hdr + TPKG__OFF_SLOT_COUNT);
+  if (slot_count == 0 || slot_count > TPKG_MAX_SLOTS) {
+    return tpkg__fail(TPKG_ERR_SLOTS);
+  }
+
+  table_off = tpkg__get64(hdr + TPKG__OFF_TABLE);
+  avail = size - TPKG_HEADER_SIZE; /* bytes preceding the header */
+  /* overflow-free: table must fit entirely before the header */
+  if (table_off > avail || (uint64_t)slot_count > (avail - table_off) / TPKG_SLOT_SIZE) {
+    return tpkg__fail(TPKG_ERR_BOUNDS);
+  }
+  if (readat(ctx, table_off, table, (size_t)slot_count * TPKG_SLOT_SIZE) != 0) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+
+  memset(out, 0, sizeof *out);
+  out->version = version;
+  out->package_flags = tpkg__get32(hdr + TPKG__OFF_PACKAGE_FLAGS);
+  out->slot_count = slot_count;
+  out->launcher_abi = tpkg__get32(hdr + TPKG__OFF_LAUNCHER_ABI);
+  memcpy(out->runtime_ref, hdr + TPKG__OFF_RUNTIME_REF, TPKG_RUNTIME_REF_LEN);
+  for (i = 0; i < slot_count; i++) {
+    const uint8_t* rec = table + (size_t)i * TPKG_SLOT_SIZE;
+    tpkg_slot* s = &out->slots[i];
+    s->offset = tpkg__get64(rec + TPKG__REC_OFFSET);
+    s->size = tpkg__get64(rec + TPKG__REC_SIZE);
+    s->format_id = tpkg__get32(rec + TPKG__REC_FORMAT);
+    s->flags = tpkg__get32(rec + TPKG__REC_FLAGS);
+    memcpy(s->mount_point, rec + TPKG__REC_MOUNT, TPKG_MOUNT_POINT_LEN);
+  }
+
+  /* structural sanity of the parsed manifest (a valid crc does not imply
+   * well-formed fields when the trailer was not written by us) */
+  return tpkg_validate(out);
+}
+
+int tpkg_read_fd(int fd, tpkg_manifest* out)
+{
+  tpkg__off_t end;
+  tpkg__last_err = TPKG_OK;
+  if (fd < 0 || out == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  end = tpkg__lseek(fd, 0, SEEK_END);
+  if (end == (tpkg__off_t)-1) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+  return tpkg__read_core(tpkg__fd_readat, &fd, (uint64_t)end, out);
+}
+
+int tpkg_read_mem(const void* data, size_t size, tpkg_manifest* out)
+{
+  tpkg__last_err = TPKG_OK;
+  if (data == NULL || out == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  return tpkg__read_core(tpkg__mem_readat, (void*)data, (uint64_t)size, out);
+}
+
+/* ---- writer ----------------------------------------------------------------- */
+
+int tpkg_write_fd(int fd, const tpkg_manifest* m)
+{
+  uint8_t buf[TPKG_MAX_SLOTS * TPKG_SLOT_SIZE + TPKG_HEADER_SIZE];
+  uint8_t* p = buf;
+  uint8_t* hdr;
+  tpkg__off_t end;
+  size_t total;
+  uint32_t i;
+
+  tpkg__last_err = TPKG_OK;
+  if (fd < 0 || m == NULL) {
+    return tpkg__fail(TPKG_ERR_ARG);
+  }
+  if (tpkg_validate(m) != 0) {
+    return -1; /* tpkg_errno set by tpkg_validate; nothing appended */
+  }
+
+  end = tpkg__lseek(fd, 0, SEEK_END);
+  if (end == (tpkg__off_t)-1) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+
+  /* slot table */
+  for (i = 0; i < m->slot_count; i++) {
+    const tpkg_slot* s = &m->slots[i];
+    tpkg__put64(p + TPKG__REC_OFFSET, s->offset);
+    tpkg__put64(p + TPKG__REC_SIZE, s->size);
+    tpkg__put32(p + TPKG__REC_FORMAT, s->format_id);
+    tpkg__put32(p + TPKG__REC_FLAGS, s->flags);
+    tpkg__put_str(p + TPKG__REC_MOUNT, s->mount_point, TPKG_MOUNT_POINT_LEN);
+    p += TPKG_SLOT_SIZE;
+  }
+
+  /* trailer header */
+  hdr = p;
+  memcpy(hdr + TPKG__OFF_MAGIC, TPKG_MAGIC, TPKG_MAGIC_LEN);
+  tpkg__put32(hdr + TPKG__OFF_VERSION, m->version);
+  tpkg__put32(hdr + TPKG__OFF_PACKAGE_FLAGS, m->package_flags);
+  tpkg__put32(hdr + TPKG__OFF_SLOT_COUNT, m->slot_count);
+  tpkg__put64(hdr + TPKG__OFF_TABLE, (uint64_t)end);
+  tpkg__put_str(hdr + TPKG__OFF_RUNTIME_REF, m->runtime_ref, TPKG_RUNTIME_REF_LEN);
+  tpkg__put32(hdr + TPKG__OFF_LAUNCHER_ABI, m->launcher_abi);
+  tpkg__put32(hdr + TPKG__OFF_CRC32, tpkg_crc32(hdr, TPKG__OFF_CRC32));
+  p += TPKG_HEADER_SIZE;
+
+  total = (size_t)(p - buf);
+  if (tpkg__write_full(fd, buf, total) != 0) {
+    return tpkg__fail(TPKG_ERR_IO);
+  }
+  return 0;
+}
+
+#endif /* TPKG_IMPLEMENTATION */

--- a/tests/test_tpkg.cpp
+++ b/tests/test_tpkg.cpp
@@ -1,0 +1,693 @@
+/**
+ * @file test_tpkg.cpp
+ * @brief Unit tests for tebako/tpkg.h — tebako package manifest (trailer) mini-lib
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+/* Declarations only — the implementation is compiled once as strict C99 in
+ * test_tpkg_c99.c (TPKG_IMPLEMENTATION) and linked into this binary, exactly
+ * like a downstream consumer. */
+#include <tebako/tpkg.h>
+
+/* Defined in test_tpkg_c99.c — proves the header compiles as strict C99. */
+extern "C" int tpkg_c99_smoke(void);
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Wire-format constants, restated from the spec (manifest trailer v1)
+// independently of the header under test, so these tests double as an
+// encoder cross-check (other languages reimplement this layout).
+// ---------------------------------------------------------------------------
+constexpr size_t kMagicOff = 0;
+constexpr size_t kVersionOff = 10;
+constexpr size_t kFlagsOff = 14;
+constexpr size_t kSlotCountOff = 18;
+constexpr size_t kTableOffOff = 22;
+constexpr size_t kRuntimeRefOff = 30;
+constexpr size_t kAbiOff = 158;
+constexpr size_t kCrcOff = 162;
+constexpr size_t kHeaderSize = 166;
+constexpr size_t kSlotSize = 280;
+constexpr char kMagic[10] = {'T', 'E', 'B', 'A', 'K', 'O', 'T', 'F', 'S', '\0'};
+
+void PutLE32(std::vector<uint8_t>& b, size_t at, uint32_t v)
+{
+  b.at(at + 0) = static_cast<uint8_t>(v & 0xFFu);
+  b.at(at + 1) = static_cast<uint8_t>((v >> 8) & 0xFFu);
+  b.at(at + 2) = static_cast<uint8_t>((v >> 16) & 0xFFu);
+  b.at(at + 3) = static_cast<uint8_t>((v >> 24) & 0xFFu);
+}
+
+void PutLE64(std::vector<uint8_t>& b, size_t at, uint64_t v)
+{
+  for (int i = 0; i < 8; i++) {
+    b.at(at + i) = static_cast<uint8_t>((v >> (8 * i)) & 0xFFu);
+  }
+}
+
+uint32_t GetLE32(const uint8_t* p)
+{
+  return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) | (static_cast<uint32_t>(p[2]) << 16) |
+         (static_cast<uint32_t>(p[3]) << 24);
+}
+
+uint64_t GetLE64(const uint8_t* p)
+{
+  uint64_t v = 0;
+  for (int i = 0; i < 8; i++) {
+    v |= static_cast<uint64_t>(p[i]) << (8 * i);
+  }
+  return v;
+}
+
+std::vector<uint8_t> Payload(size_t n)
+{
+  std::vector<uint8_t> b(n);
+  for (size_t i = 0; i < n; i++) {
+    b[i] = static_cast<uint8_t>((i * 31 + 7) & 0xFF);
+  }
+  return b;
+}
+
+std::vector<uint8_t> ReadFile(const std::filesystem::path& p)
+{
+  std::ifstream in(p, std::ios::binary);
+  EXPECT_TRUE(in.good()) << "cannot open " << p;
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+void WriteFile(const std::filesystem::path& p, const std::vector<uint8_t>& bytes)
+{
+  std::ofstream out(p, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(out.good()) << "cannot create " << p;
+  out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+  ASSERT_TRUE(out.good()) << "cannot write " << p;
+}
+
+class TempFile {
+ public:
+  explicit TempFile(const char* tag)
+  {
+    static int counter = 0;
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    path_ = std::filesystem::temp_directory_path() /
+            ("tpkg_test_" + std::string(info ? info->name() : "anon") + "_" + tag + "_" + std::to_string(counter++));
+  }
+  ~TempFile()
+  {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+  }
+  TempFile(const TempFile&) = delete;
+  TempFile& operator=(const TempFile&) = delete;
+  const std::filesystem::path& path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+int OpenFd(const std::filesystem::path& p, bool writable)
+{
+#ifdef _WIN32
+  return ::_open(p.string().c_str(), (writable ? _O_RDWR : _O_RDONLY) | _O_BINARY);
+#else
+  return ::open(p.string().c_str(), writable ? O_RDWR : O_RDONLY);
+#endif
+}
+
+void CloseFd(int fd)
+{
+#ifdef _WIN32
+  ::_close(fd);
+#else
+  ::close(fd);
+#endif
+}
+
+tpkg_manifest MakeManifest(uint32_t slots)
+{
+  tpkg_manifest m{};
+  m.version = TPKG_VERSION;
+  m.package_flags = 0;
+  m.slot_count = slots;
+  m.launcher_abi = 1;
+  for (uint32_t i = 0; i < slots && i < TPKG_MAX_SLOTS; i++) {
+    m.slots[i].offset = 4096ull * (i + 1);
+    m.slots[i].size = 2048ull * (i + 1);
+    m.slots[i].format_id = TPKG_FORMAT_AUTO;
+    m.slots[i].flags = 0;
+    std::snprintf(m.slots[i].mount_point, TPKG_MOUNT_POINT_LEN, "/mnt/slot%u", i);
+  }
+  return m;
+}
+
+// Creates a stitched file: payload bytes + slot table + trailer header,
+// appended via the API under test.
+void CreateStitchedFile(const std::filesystem::path& p, const std::vector<uint8_t>& payload, const tpkg_manifest& m)
+{
+  WriteFile(p, payload);
+  int fd = OpenFd(p, true);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(0, tpkg_write_fd(fd, &m)) << "tpkg_write_fd failed: " << tpkg_strerror(tpkg_errno());
+  CloseFd(fd);
+}
+
+// Builds a 166-byte trailer header by hand (independent LE encoder), using
+// the public tpkg_crc32 (itself pinned by the known-vector test) for the crc.
+std::vector<uint8_t> CraftHeader(uint32_t version, uint32_t flags, uint32_t slot_count, uint64_t table_off,
+                                 const std::string& runtime_ref, uint32_t abi)
+{
+  std::vector<uint8_t> h(kHeaderSize, 0);
+  std::memcpy(h.data() + kMagicOff, kMagic, sizeof kMagic);
+  PutLE32(h, kVersionOff, version);
+  PutLE32(h, kFlagsOff, flags);
+  PutLE32(h, kSlotCountOff, slot_count);
+  PutLE64(h, kTableOffOff, table_off);
+  std::memcpy(h.data() + kRuntimeRefOff, runtime_ref.data(), std::min<size_t>(runtime_ref.size(), 128));
+  PutLE32(h, kAbiOff, abi);
+  PutLE32(h, kCrcOff, tpkg_crc32(h.data(), kCrcOff));
+  return h;
+}
+
+void ExpectManifestEq(const tpkg_manifest& a, const tpkg_manifest& b)
+{
+  EXPECT_EQ(a.version, b.version);
+  EXPECT_EQ(a.package_flags, b.package_flags);
+  EXPECT_EQ(a.slot_count, b.slot_count);
+  EXPECT_EQ(a.launcher_abi, b.launcher_abi);
+  EXPECT_EQ(0, std::memcmp(a.runtime_ref, b.runtime_ref, TPKG_RUNTIME_REF_LEN));
+  for (uint32_t i = 0; i < a.slot_count && i < TPKG_MAX_SLOTS; i++) {
+    EXPECT_EQ(a.slots[i].offset, b.slots[i].offset) << "slot " << i;
+    EXPECT_EQ(a.slots[i].size, b.slots[i].size) << "slot " << i;
+    EXPECT_EQ(a.slots[i].format_id, b.slots[i].format_id) << "slot " << i;
+    EXPECT_EQ(a.slots[i].flags, b.slots[i].flags) << "slot " << i;
+    EXPECT_EQ(0, std::memcmp(a.slots[i].mount_point, b.slots[i].mount_point, TPKG_MOUNT_POINT_LEN)) << "slot " << i;
+  }
+}
+
+}  // namespace
+
+// ============================================================================
+// tpkg_crc32
+// ============================================================================
+
+TEST(TpkgCrc32, KnownVector)
+{
+  /* Classic zlib CRC-32 check value */
+  EXPECT_EQ(tpkg_crc32("123456789", 9), 0xCBF43926u);
+  EXPECT_EQ(tpkg_crc32("", 0), 0u);
+}
+
+// ============================================================================
+// tpkg_validate
+// ============================================================================
+
+TEST(TpkgValidate, ValidManifestAccepted)
+{
+  auto single = MakeManifest(1);
+  EXPECT_EQ(0, tpkg_validate(&single)) << tpkg_strerror(tpkg_errno());
+  auto full = MakeManifest(TPKG_MAX_SLOTS);
+  EXPECT_EQ(0, tpkg_validate(&full)) << tpkg_strerror(tpkg_errno());
+}
+
+TEST(TpkgValidate, ZeroSlotsRejected)
+{
+  auto m = MakeManifest(1);
+  m.slot_count = 0;
+  EXPECT_EQ(-1, tpkg_validate(&m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_SLOTS);
+}
+
+TEST(TpkgValidate, TooManySlotsRejected)
+{
+  auto m = MakeManifest(TPKG_MAX_SLOTS);
+  m.slot_count = TPKG_MAX_SLOTS + 1;
+  EXPECT_EQ(-1, tpkg_validate(&m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_SLOTS);
+}
+
+TEST(TpkgValidate, MountPointNotNulTerminatedRejected)
+{
+  auto m = MakeManifest(1);
+  std::memset(m.slots[0].mount_point, 'x', TPKG_MOUNT_POINT_LEN); /* no NUL */
+  EXPECT_EQ(-1, tpkg_validate(&m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_INVALID);
+}
+
+TEST(TpkgValidate, RuntimeRefNotNulTerminatedRejected)
+{
+  auto m = MakeManifest(1);
+  std::memset(m.runtime_ref, 'r', TPKG_RUNTIME_REF_LEN); /* no NUL */
+  EXPECT_EQ(-1, tpkg_validate(&m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_INVALID);
+}
+
+TEST(TpkgValidate, OffsetSizeOverflowRejected)
+{
+  auto m = MakeManifest(1);
+  m.slots[0].offset = UINT64_MAX;
+  m.slots[0].size = 2; /* offset + size wraps */
+  EXPECT_EQ(-1, tpkg_validate(&m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_INVALID);
+}
+
+TEST(TpkgValidate, BadFormatIdRejected)
+{
+  auto m = MakeManifest(1);
+  m.slots[0].format_id = 4;
+  EXPECT_EQ(-1, tpkg_validate(&m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_INVALID);
+  for (uint32_t f = TPKG_FORMAT_AUTO; f <= TPKG_FORMAT_ZIP; f++) {
+    m.slots[0].format_id = f;
+    EXPECT_EQ(0, tpkg_validate(&m)) << "format_id " << f;
+  }
+}
+
+TEST(TpkgValidate, NullArgumentRejected)
+{
+  auto m = MakeManifest(1);
+  EXPECT_EQ(-1, tpkg_validate(nullptr));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_ARG);
+  EXPECT_EQ(-1, tpkg_read_mem(nullptr, 100, &m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_ARG);
+  uint8_t buf[256] = {0};
+  EXPECT_EQ(-1, tpkg_read_mem(buf, sizeof buf, nullptr));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_ARG);
+}
+
+// ============================================================================
+// tpkg_write_fd input validation
+// ============================================================================
+
+TEST(TpkgWriteFd, ZeroSlotsWriteRejected)
+{
+  TempFile tmp("w0");
+  WriteFile(tmp.path(), Payload(64));
+  auto m = MakeManifest(1);
+  m.slot_count = 0;
+  int fd = OpenFd(tmp.path(), true);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(-1, tpkg_write_fd(fd, &m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_SLOTS);
+  CloseFd(fd);
+  EXPECT_EQ(ReadFile(tmp.path()).size(), 64u) << "rejected write must not append";
+}
+
+TEST(TpkgWriteFd, TooManySlotsWriteRejected)
+{
+  TempFile tmp("w9");
+  WriteFile(tmp.path(), Payload(64));
+  auto m = MakeManifest(TPKG_MAX_SLOTS);
+  m.slot_count = TPKG_MAX_SLOTS + 1;
+  int fd = OpenFd(tmp.path(), true);
+  ASSERT_GE(fd, 0);
+  EXPECT_EQ(-1, tpkg_write_fd(fd, &m));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_SLOTS);
+  CloseFd(fd);
+  EXPECT_EQ(ReadFile(tmp.path()).size(), 64u) << "rejected write must not append";
+}
+
+// ============================================================================
+// Round trips: write -> read -> validate
+// ============================================================================
+
+TEST(TpkgRoundTrip, SingleSlotFd)
+{
+  TempFile tmp("rt1");
+  auto m = MakeManifest(1);
+  m.slots[0].offset = 0;
+  m.slots[0].size = 4096;
+  m.slots[0].format_id = TPKG_FORMAT_DWARFS;
+  std::strcpy(m.slots[0].mount_point, "/__tebako_memfs__");
+  CreateStitchedFile(tmp.path(), Payload(4096), m);
+
+  int fd = OpenFd(tmp.path(), false);
+  ASSERT_GE(fd, 0);
+  tpkg_manifest read{};
+  ASSERT_EQ(0, tpkg_read_fd(fd, &read)) << tpkg_strerror(tpkg_errno());
+  EXPECT_EQ(tpkg_errno(), TPKG_OK);
+  CloseFd(fd);
+  EXPECT_EQ(0, tpkg_validate(&read)) << tpkg_strerror(tpkg_errno());
+  ExpectManifestEq(m, read);
+}
+
+TEST(TpkgRoundTrip, SingleSlotMem)
+{
+  TempFile tmp("rt2");
+  auto m = MakeManifest(1);
+  CreateStitchedFile(tmp.path(), Payload(4096), m);
+
+  auto bytes = ReadFile(tmp.path());
+  tpkg_manifest read{};
+  ASSERT_EQ(0, tpkg_read_mem(bytes.data(), bytes.size(), &read)) << tpkg_strerror(tpkg_errno());
+  EXPECT_EQ(0, tpkg_validate(&read));
+  ExpectManifestEq(m, read);
+}
+
+TEST(TpkgRoundTrip, ThreeSlotsWithRuntimeRef)
+{
+  TempFile tmp("rt3");
+  tpkg_manifest m{};
+  m.version = TPKG_VERSION;
+  m.package_flags = 0;
+  m.slot_count = 3;
+  m.launcher_abi = 1;
+  std::strcpy(m.runtime_ref, "ruby@3.3.7;tebako=0.15.0");
+
+  m.slots[0].offset = 0;
+  m.slots[0].size = 1000;
+  m.slots[0].format_id = TPKG_FORMAT_DWARFS;
+  m.slots[0].flags = 0;
+  std::strcpy(m.slots[0].mount_point, "/app");
+
+  m.slots[1].offset = 1000;
+  m.slots[1].size = 2000;
+  m.slots[1].format_id = TPKG_FORMAT_SQUASHFS;
+  m.slots[1].flags = 1;
+  std::strcpy(m.slots[1].mount_point, "/gems");
+
+  m.slots[2].offset = 3000;
+  m.slots[2].size = 512;
+  m.slots[2].format_id = TPKG_FORMAT_ZIP;
+  m.slots[2].flags = 0;
+  std::strcpy(m.slots[2].mount_point, "/data");
+
+  CreateStitchedFile(tmp.path(), Payload(3512), m);
+
+  auto bytes = ReadFile(tmp.path());
+  tpkg_manifest read{};
+  ASSERT_EQ(0, tpkg_read_mem(bytes.data(), bytes.size(), &read)) << tpkg_strerror(tpkg_errno());
+  EXPECT_EQ(0, tpkg_validate(&read));
+  EXPECT_STREQ(read.runtime_ref, "ruby@3.3.7;tebako=0.15.0");
+  ExpectManifestEq(m, read);
+}
+
+TEST(TpkgRoundTrip, LeanFlagPreserved)
+{
+  TempFile tmp("lean");
+  ASSERT_EQ(TPKG_FLAG_LEAN, 1u) << "LEAN must be package_flags bit 0";
+  auto m = MakeManifest(1);
+  m.package_flags = TPKG_FLAG_LEAN;
+  std::strcpy(m.runtime_ref, "ruby@3.3.7;tebako=0.15.0");
+  CreateStitchedFile(tmp.path(), Payload(2048), m);
+
+  auto bytes = ReadFile(tmp.path());
+  tpkg_manifest read{};
+  ASSERT_EQ(0, tpkg_read_mem(bytes.data(), bytes.size(), &read)) << tpkg_strerror(tpkg_errno());
+  EXPECT_TRUE((read.package_flags & TPKG_FLAG_LEAN) != 0);
+  ExpectManifestEq(m, read);
+}
+
+TEST(TpkgRoundTrip, MaxSlotsRoundTrip)
+{
+  TempFile tmp("rt8");
+  auto m = MakeManifest(TPKG_MAX_SLOTS);
+  CreateStitchedFile(tmp.path(), Payload(8192), m);
+
+  auto bytes = ReadFile(tmp.path());
+  ASSERT_EQ(bytes.size(), 8192u + TPKG_MAX_SLOTS * kSlotSize + kHeaderSize);
+  tpkg_manifest read{};
+  ASSERT_EQ(0, tpkg_read_mem(bytes.data(), bytes.size(), &read)) << tpkg_strerror(tpkg_errno());
+  EXPECT_EQ(read.slot_count, TPKG_MAX_SLOTS);
+  ExpectManifestEq(m, read);
+}
+
+TEST(TpkgRoundTrip, OddFileOffsets)
+{
+  /* trailer + table written at non-aligned file offsets must round-trip */
+  for (size_t payload_size : {size_t{1}, size_t{513}, size_t{4097}}) {
+    TempFile tmp("odd");
+    auto m = MakeManifest(1);
+    m.slots[0].offset = 13; /* odd slot geometry too */
+    m.slots[0].size = 4097;
+    CreateStitchedFile(tmp.path(), Payload(payload_size), m);
+
+    auto bytes = ReadFile(tmp.path());
+    ASSERT_EQ(bytes.size(), payload_size + kSlotSize + kHeaderSize);
+    const uint8_t* hdr = bytes.data() + bytes.size() - kHeaderSize;
+    EXPECT_EQ(GetLE64(hdr + kTableOffOff), payload_size) << "payload " << payload_size;
+
+    tpkg_manifest read{};
+    ASSERT_EQ(0, tpkg_read_mem(bytes.data(), bytes.size(), &read)) << "payload " << payload_size;
+    ExpectManifestEq(m, read);
+
+    int fd = OpenFd(tmp.path(), false);
+    ASSERT_GE(fd, 0);
+    tpkg_manifest read_fd{};
+    ASSERT_EQ(0, tpkg_read_fd(fd, &read_fd)) << "payload " << payload_size;
+    CloseFd(fd);
+    ExpectManifestEq(m, read_fd);
+  }
+}
+
+// ============================================================================
+// Absent vs corrupt trailer
+// ============================================================================
+
+TEST(TpkgRead, AbsentTrailerMem)
+{
+  auto no_trailer = std::vector<uint8_t>(4096, 0xAB);
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(no_trailer.data(), no_trailer.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_NO_TRAILER);
+
+  /* too small to hold a fixed-size header at all */
+  auto tiny = std::vector<uint8_t>(100, 0xCD);
+  EXPECT_EQ(-1, tpkg_read_mem(tiny.data(), tiny.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_NO_TRAILER);
+}
+
+TEST(TpkgRead, AbsentTrailerFd)
+{
+  TempFile tmp("absent");
+  WriteFile(tmp.path(), std::vector<uint8_t>(4096, 0xAB));
+  int fd = OpenFd(tmp.path(), false);
+  ASSERT_GE(fd, 0);
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_fd(fd, &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_NO_TRAILER);
+  CloseFd(fd);
+}
+
+TEST(TpkgRead, CorruptMagicRejected)
+{
+  TempFile tmp("cmagic");
+  auto m = MakeManifest(1);
+  CreateStitchedFile(tmp.path(), Payload(512), m);
+  auto bytes = ReadFile(tmp.path());
+
+  /* flip a magic byte past the 4-byte "TEBA" prefix: prefix matches, full
+     magic does not -> corrupt, not absent */
+  size_t hdr = bytes.size() - kHeaderSize;
+  ASSERT_EQ(bytes[hdr + 6], 'T');
+  bytes[hdr + 6] = 'X';
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_MAGIC);
+}
+
+TEST(TpkgRead, MagicPrefixMismatchMeansAbsent)
+{
+  TempFile tmp("pmagic");
+  auto m = MakeManifest(1);
+  CreateStitchedFile(tmp.path(), Payload(512), m);
+  auto bytes = ReadFile(tmp.path());
+
+  /* break the "TEBA" prefix: indistinguishable from a binary with no trailer */
+  size_t hdr = bytes.size() - kHeaderSize;
+  bytes[hdr + 1] = 'Z';
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_NO_TRAILER);
+}
+
+TEST(TpkgRead, CorruptCrcRejected)
+{
+  TempFile tmp("ccrc");
+  auto m = MakeManifest(1);
+  std::strcpy(m.runtime_ref, "ruby@3.3.7;tebako=0.15.0");
+  CreateStitchedFile(tmp.path(), Payload(512), m);
+  auto bytes = ReadFile(tmp.path());
+  size_t hdr = bytes.size() - kHeaderSize;
+  tpkg_manifest read{};
+
+  /* flip a crc-covered payload byte (runtime_ref region) */
+  auto corrupted = bytes;
+  corrupted[hdr + kRuntimeRefOff + 3] ^= 0xFF;
+  EXPECT_EQ(-1, tpkg_read_mem(corrupted.data(), corrupted.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_CRC);
+
+  /* flip a byte of the stored crc field itself */
+  corrupted = bytes;
+  corrupted[hdr + kCrcOff] ^= 0xFF;
+  EXPECT_EQ(-1, tpkg_read_mem(corrupted.data(), corrupted.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_CRC);
+}
+
+// ============================================================================
+// Hand-crafted hostile headers (valid crc, bad structure)
+// ============================================================================
+
+TEST(TpkgRead, CraftedZeroSlotCountRejected)
+{
+  auto bytes = Payload(256);
+  auto hdr = CraftHeader(TPKG_VERSION, 0, /*slot_count=*/0, 256, "", 1);
+  bytes.insert(bytes.end(), hdr.begin(), hdr.end());
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_SLOTS);
+}
+
+TEST(TpkgRead, CraftedExcessiveSlotCountRejected)
+{
+  auto bytes = Payload(256);
+  auto hdr = CraftHeader(TPKG_VERSION, 0, /*slot_count=*/TPKG_MAX_SLOTS + 1, 256, "", 1);
+  bytes.insert(bytes.end(), hdr.begin(), hdr.end());
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_SLOTS);
+}
+
+TEST(TpkgRead, CraftedUnsupportedVersionRejected)
+{
+  auto bytes = Payload(256);
+  auto hdr = CraftHeader(/*version=*/2, 0, 1, 256, "", 1);
+  bytes.insert(bytes.end(), hdr.begin(), hdr.end());
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_VERSION);
+}
+
+TEST(TpkgRead, TruncatedSlotTableRejected)
+{
+  /* header claims one slot whose table record is not actually in the file */
+  auto bytes = Payload(256);
+  auto hdr = CraftHeader(TPKG_VERSION, 0, 1, /*table_off=*/256, "", 1);
+  bytes.insert(bytes.end(), hdr.begin(), hdr.end()); /* no 280-byte table */
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_BOUNDS);
+}
+
+TEST(TpkgRead, TableOffsetBeyondEofRejected)
+{
+  auto bytes = Payload(256);
+  auto hdr = CraftHeader(TPKG_VERSION, 0, 1, /*table_off=*/1u << 20, "", 1);
+  bytes.insert(bytes.end(), hdr.begin(), hdr.end());
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_BOUNDS);
+}
+
+TEST(TpkgRead, CraftedUnterminatedMountPointRejected)
+{
+  /* valid crc, but the slot's mount_point has no NUL in 256 bytes */
+  auto bytes = Payload(256);
+  std::vector<uint8_t> rec(kSlotSize, 0);
+  PutLE64(rec, 0, 0);
+  PutLE64(rec, 8, 128);
+  PutLE32(rec, 16, TPKG_FORMAT_DWARFS);
+  PutLE32(rec, 20, 0);
+  std::memset(rec.data() + 24, 'x', 256);
+  auto hdr = CraftHeader(TPKG_VERSION, 0, 1, 256, "", 1);
+  bytes.insert(bytes.end(), rec.begin(), rec.end());
+  bytes.insert(bytes.end(), hdr.begin(), hdr.end());
+  tpkg_manifest read{};
+  EXPECT_EQ(-1, tpkg_read_mem(bytes.data(), bytes.size(), &read));
+  EXPECT_EQ(tpkg_errno(), TPKG_ERR_INVALID);
+}
+
+// ============================================================================
+// Wire format (the exact layout other languages will reimplement)
+// ============================================================================
+
+TEST(TpkgWireFormat, LayoutAndSizes)
+{
+  EXPECT_EQ(TPKG_HEADER_SIZE, kHeaderSize);
+  EXPECT_EQ(TPKG_SLOT_SIZE, kSlotSize);
+  EXPECT_EQ(TPKG_MAX_SLOTS, 8u);
+  EXPECT_EQ(TPKG_VERSION, 1u);
+  EXPECT_EQ(TPKG_MOUNT_POINT_LEN, 256u);
+  EXPECT_EQ(TPKG_RUNTIME_REF_LEN, 128u);
+  EXPECT_EQ(TPKG_FORMAT_AUTO, 0u);
+  EXPECT_EQ(TPKG_FORMAT_DWARFS, 1u);
+  EXPECT_EQ(TPKG_FORMAT_SQUASHFS, 2u);
+  EXPECT_EQ(TPKG_FORMAT_ZIP, 3u);
+
+  TempFile tmp("wire");
+  tpkg_manifest m{};
+  m.version = TPKG_VERSION;
+  m.package_flags = TPKG_FLAG_LEAN;
+  m.slot_count = 1;
+  m.launcher_abi = 1;
+  std::strcpy(m.runtime_ref, "ruby@3.3.7;tebako=0.15.0");
+  m.slots[0].offset = 7;
+  m.slots[0].size = 999;
+  m.slots[0].format_id = TPKG_FORMAT_ZIP;
+  m.slots[0].flags = 5;
+  std::strcpy(m.slots[0].mount_point, "/app");
+
+  CreateStitchedFile(tmp.path(), Payload(111), m);
+  auto bytes = ReadFile(tmp.path());
+  ASSERT_EQ(bytes.size(), 111u + kSlotSize + kHeaderSize);
+
+  /* slot record at byte 111 */
+  const uint8_t* rec = bytes.data() + 111;
+  EXPECT_EQ(GetLE64(rec + 0), 7u);
+  EXPECT_EQ(GetLE64(rec + 8), 999u);
+  EXPECT_EQ(GetLE32(rec + 16), TPKG_FORMAT_ZIP);
+  EXPECT_EQ(GetLE32(rec + 20), 5u);
+  EXPECT_EQ(0, std::memcmp(rec + 24, "/app", 5));
+  EXPECT_EQ(rec[24 + 255], 0) << "mount_point must be NUL-padded";
+
+  /* header at EOF-166 */
+  const uint8_t* hdr = bytes.data() + bytes.size() - kHeaderSize;
+  EXPECT_EQ(0, std::memcmp(hdr + kMagicOff, kMagic, 10));
+  EXPECT_EQ(GetLE32(hdr + kVersionOff), 1u);
+  EXPECT_EQ(GetLE32(hdr + kFlagsOff), TPKG_FLAG_LEAN);
+  EXPECT_EQ(GetLE32(hdr + kSlotCountOff), 1u);
+  EXPECT_EQ(GetLE64(hdr + kTableOffOff), 111u);
+  EXPECT_EQ(0, std::memcmp(hdr + kRuntimeRefOff, "ruby@3.3.7;tebako=0.15.0", 24));
+  EXPECT_EQ(hdr[kRuntimeRefOff + 127], 0) << "runtime_ref must be NUL-padded";
+  EXPECT_EQ(GetLE32(hdr + kAbiOff), 1u);
+  EXPECT_EQ(GetLE32(hdr + kCrcOff), tpkg_crc32(hdr, kCrcOff)) << "crc32 covers header bytes [0,162)";
+}
+
+// ============================================================================
+// strerror / C99 conformance
+// ============================================================================
+
+TEST(TpkgStrError, AllCodesHaveStrings)
+{
+  for (int code : {TPKG_OK, TPKG_ERR_NO_TRAILER, TPKG_ERR_MAGIC, TPKG_ERR_CRC, TPKG_ERR_IO, TPKG_ERR_BOUNDS,
+                   TPKG_ERR_SLOTS, TPKG_ERR_INVALID, TPKG_ERR_ARG, TPKG_ERR_VERSION}) {
+    const char* s = tpkg_strerror(code);
+    ASSERT_NE(s, nullptr) << "code " << code;
+    EXPECT_GT(std::strlen(s), 0u) << "code " << code;
+  }
+  EXPECT_NE(tpkg_strerror(12345), nullptr) << "unknown codes need a fallback string";
+}
+
+TEST(TpkgC99, HeaderCompilesAsC99)
+{
+  EXPECT_EQ(tpkg_c99_smoke(), 0);
+}

--- a/tests/test_tpkg_c99.c
+++ b/tests/test_tpkg_c99.c
@@ -1,0 +1,49 @@
+/**
+ * @file test_tpkg_c99.c
+ * @brief Strict-C99 translation unit proving tebako/tpkg.h compiles as C99.
+ *
+ * Built with C_STANDARD 99 / C_EXTENSIONS OFF (see CMakeLists). Exercised
+ * from test_tpkg.cpp via tpkg_c99_smoke().
+ */
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ < 199901L)
+#error "tpkg.h must compile as C99 or later"
+#endif
+
+#define TPKG_IMPLEMENTATION
+#include <tebako/tpkg.h>
+
+#include <string.h>
+
+int tpkg_c99_smoke(void)
+{
+  tpkg_manifest m;
+  uint32_t crc;
+
+  memset(&m, 0, sizeof m);
+  m.version = TPKG_VERSION;
+  m.package_flags = TPKG_FLAG_LEAN;
+  m.slot_count = 1;
+  m.launcher_abi = 1;
+  strcpy(m.runtime_ref, "ruby@3.3.7;tebako=0.15.0");
+  m.slots[0].offset = 0;
+  m.slots[0].size = 4096;
+  m.slots[0].format_id = TPKG_FORMAT_DWARFS;
+  m.slots[0].flags = 0;
+  strcpy(m.slots[0].mount_point, "/app");
+
+  crc = tpkg_crc32("123456789", 9);
+  if (crc != 0xCBF43926u) {
+    return 2;
+  }
+  if (tpkg_validate(&m) != 0) {
+    return 3;
+  }
+  if (tpkg_errno() != TPKG_OK) {
+    return 4;
+  }
+  if (tpkg_strerror(TPKG_ERR_NO_TRAILER) == NULL) {
+    return 5;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary

Stage 3A-1 of the tebako thrift-free master plan (spec §4.3, `2026-07-19-tebako-thrift-free-master-plan-design.md` in the tamatebako workspace): `include/tebako/tpkg.h` — a single-header C99 mini-lib (no dependencies beyond libc) implementing the tebako manifest trailer format for stitched binaries. Consumed next by tebako-main (3A-2), the bootstrap launcher (3B-1), and `tebakofs` (3B-4); designed to be trivially reimplementable from other languages (the Ruby stitcher writes this format).

## Format (v1, fixed layout, all integers little-endian)

```
[payload][slot 0..n-1 records][trailer header — fixed 166 B at EOF]
trailer header: magic "TEBAKOTFS\0" (10 B) | u32 version | u32 package_flags |
                u32 slot_count | u64 slot_table_offset | runtime_ref[128] |
                u32 launcher_abi | u32 header_crc32  (crc over header bytes [0,162))
slot record (280 B): u64 offset | u64 size | u32 format_id | u32 flags | mount_point[256]
```

- `format_id`: 0=auto(magic), 1=dwarfs, 2=squashfs, 3=zip
- `package_flags` bit 0: `TPKG_FLAG_LEAN` (bootstrap+images only)
- CRC-32 (zlib polynomial) implemented in-header
- Absent vs corrupt: no `"TEBA"` prefix at `EOF−166` → `TPKG_ERR_NO_TRAILER` (classic bundle, not an error — callers fall back to offset auto-detection); prefix match + full-magic mismatch → `TPKG_ERR_MAGIC`; bad crc → `TPKG_ERR_CRC`

## API

```c
int  tpkg_read_fd(int fd, tpkg_manifest* out);
int  tpkg_read_mem(const void* data, size_t size, tpkg_manifest* out);
int  tpkg_write_fd(int fd, const tpkg_manifest* m);   /* appends table + trailer at EOF */
int  tpkg_validate(const tpkg_manifest* m);
uint32_t tpkg_crc32(const void* data, size_t n);
int  tpkg_errno(void);
const char* tpkg_strerror(int err);
```

`TPKG_MAX_SLOTS` = 8. Reads validate structure before returning success; writes validate before appending anything. Error state is process-global (documented, not thread-safe — C99 has no portable TLS).

## Tests

`tests/test_tpkg.cpp` — 31 gtest cases wired into CTest like the other suites:
- round trips write→read→validate (fd + in-memory; 1, 3 and 8 slots; `runtime_ref "ruby@3.3.7;tebako=0.15.0"`; LEAN flag; trailer at odd file offsets 1/513/4097)
- absent trailer (distinct code, mem + fd), corrupt magic, corrupt CRC (flipped payload byte and flipped crc field)
- hand-crafted hostile headers with valid CRC: zero slots, slot_count > TPKG_MAX_SLOTS, unsupported version, truncated slot table, table offset beyond EOF, unterminated mount point
- validate rejects: zero/excessive slot count, unterminated mount_point/runtime_ref, offset+size overflow, format_id > 3
- exact wire-layout assertions (offsets, LE encoding, NUL padding, crc coverage) as a cross-check for reimplementers
- `tests/test_tpkg_c99.c` — a `-std=c99` (extensions off) translation unit proving the header is C99-clean; the gtest binary links against that C-compiled implementation like a downstream consumer

## Verification

Full local build + `ctest` on macOS arm64: **411/411 pass** (380 pre-existing + 31 new). No changes outside `include/tebako/tpkg.h`, `tests/test_tpkg{,.cpp,_c99.c}` and the CMake wiring.