### PR TITLE
feat: mount-from-file-at-offset C API (tebako_fs_init_from_file_at)

### DIFF
--- a/include/tebako/fs/c_api.h
+++ b/include/tebako/fs/c_api.h
@@ -93,6 +93,41 @@ extern "C" {
 int tebako_fs_init_from_file(const char* archive_path, const char* mount_point);
 
 /**
+ * @brief Initialize libtfs from a region of a file
+ *
+ * Mounts `length` bytes starting at byte `offset` of the archive file at the
+ * specified mount point. The archive format is auto-detected from the region
+ * content (DwarFS, ZIP, SquashFS).
+ *
+ * This allows mounting an image embedded inside a larger file (e.g., appended
+ * to an executable or stored alongside a manifest trailer) without copying
+ * the surrounding data.
+ *
+ * @param archive_path Path to the file containing the archive
+ * @param offset Byte offset of the archive start within the file
+ * @param length Length of the archive in bytes; 0 means "to end of file"
+ * @param mount_point Virtual mount point (e.g., "/__tebako__")
+ * @return 0 on success, -1 on error (check errno via tebako_get_errno())
+ *
+ * @note Only one filesystem can be mounted at a time
+ * @note Calling this while already mounted returns -1 with errno=EEXIST
+ * @note offset == 0 && length == 0 mounts the whole file directly (zero-copy);
+ *       any other region is read into memory owned by libtfs until
+ *       tebako_fs_unmount()
+ * @note Returns -1 with errno=ENOENT if the file does not exist, errno=EINVAL
+ *       if offset is past end of file or offset+length exceeds the file size
+ *
+ * @example
+ * @code
+ * // Mount a DwarFS image stored at offset 4096 of a package file
+ * if (tebako_fs_init_from_file_at("/app/pkg.bin", 4096, 0, "/__tebako__") == 0) {
+ *     // Filesystem ready for use
+ * }
+ * @endcode
+ */
+int tebako_fs_init_from_file_at(const char* archive_path, uint64_t offset, uint64_t length, const char* mount_point);
+
+/**
  * @brief Initialize libtfs from memory-embedded image
  *
  * Mounts an archive from memory (typically embedded in executable).

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -41,6 +41,7 @@
 #include <fstream>
 #include <filesystem>
 #include <chrono>
+#include <limits>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -69,6 +70,11 @@ std::unique_ptr<tebako::fs::FileSystem> g_filesystem;
 std::mutex g_init_mutex;
 bool g_initialized = false;
 std::string g_mount_point;
+
+// Owned image region for tebako_fs_init_from_file_at() mounts.
+// Kept alive until tebako_fs_unmount() because mount_from_memory()
+// requires the buffer to outlive the mounted filesystem.
+std::unique_ptr<char[]> g_image_region;
 
 // FD table: internal FD -> FileHandle
 std::unordered_map<int, std::unique_ptr<tebako::fs::FileHandle>> g_fd_table;
@@ -332,6 +338,14 @@ void handle_exception()
 
 extern "C" int tebako_fs_init_from_file(const char* archive_path, const char* mount_point)
 {
+  return tebako_fs_init_from_file_at(archive_path, 0, 0, mount_point);
+}
+
+extern "C" int tebako_fs_init_from_file_at(const char* archive_path,
+                                           uint64_t offset,
+                                           uint64_t length,
+                                           const char* mount_point)
+{
   if (archive_path == nullptr || mount_point == nullptr) {
     set_errno(EINVAL);
     return -1;
@@ -345,19 +359,85 @@ extern "C" int tebako_fs_init_from_file(const char* archive_path, const char* mo
   }
 
   try {
-    // Auto-detect format and create backend
-    g_filesystem = tebako::fs::BackendFactory::create_from_file(archive_path);
+    if (offset == 0 && length == 0) {
+      // Whole-file mount: zero-copy path (backend reads/mmaps the file itself)
+      g_filesystem = tebako::fs::BackendFactory::create_from_file(archive_path);
 
-    if (!g_filesystem) {
-      set_errno(EINVAL);
-      return -1;
+      if (!g_filesystem) {
+        set_errno(EINVAL);
+        return -1;
+      }
+
+      if (!g_filesystem->mount(archive_path, mount_point)) {
+        g_filesystem.reset();
+        set_errno(EIO);
+        return -1;
+      }
     }
+    else {
+      // Region mount: read [offset, offset+length) into an owned buffer and
+      // mount it from memory
+      std::error_code ec;
+      const uint64_t file_size = std::filesystem::file_size(archive_path, ec);
+      if (ec) {
+        g_filesystem.reset();
+        set_errno(ENOENT);
+        return -1;
+      }
 
-    // Mount filesystem
-    if (!g_filesystem->mount(archive_path, mount_point)) {
-      g_filesystem.reset();
-      set_errno(EIO);
-      return -1;
+      if (offset > file_size) {
+        set_errno(EINVAL);  // offset past end of file
+        return -1;
+      }
+
+      uint64_t region = length;
+      if (region == 0) {
+        region = file_size - offset;  // 0 length = to end of file
+      }
+      else if (region > file_size - offset) {
+        set_errno(EINVAL);  // offset+length extends past end of file
+        return -1;
+      }
+
+      if (region == 0 || region > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max())) {
+        set_errno(EINVAL);
+        return -1;
+      }
+
+      auto buffer = std::make_unique<char[]>(static_cast<size_t>(region));
+
+      std::ifstream ifs(archive_path, std::ios::binary);
+      if (!ifs.is_open()) {
+        set_errno(ENOENT);
+        return -1;
+      }
+      ifs.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+      if (!ifs.good()) {
+        set_errno(EIO);
+        return -1;
+      }
+      ifs.read(buffer.get(), static_cast<std::streamsize>(region));
+      if (ifs.gcount() != static_cast<std::streamsize>(region)) {
+        set_errno(EIO);
+        return -1;
+      }
+      ifs.close();
+
+      g_filesystem = tebako::fs::BackendFactory::create_from_memory(buffer.get(), static_cast<size_t>(region));
+
+      if (!g_filesystem) {
+        set_errno(EINVAL);
+        return -1;
+      }
+
+      if (!g_filesystem->mount_from_memory(buffer.get(), static_cast<size_t>(region), mount_point)) {
+        g_filesystem.reset();
+        set_errno(EIO);
+        return -1;
+      }
+
+      // Backend mounted from memory: buffer must stay alive until unmount
+      g_image_region = std::move(buffer);
     }
 
     g_mount_point = mount_point;
@@ -367,6 +447,7 @@ extern "C" int tebako_fs_init_from_file(const char* archive_path, const char* mo
   }
   catch (...) {
     g_filesystem.reset();
+    g_image_region.reset();
     handle_exception();
     return -1;
   }
@@ -441,6 +522,9 @@ extern "C" void tebako_fs_unmount(void)
     g_filesystem->unmount();
     g_filesystem.reset();
   }
+
+  // Release any owned image region (tebako_fs_init_from_file_at)
+  g_image_region.reset();
 
   g_mount_point.clear();
   g_initialized = false;
@@ -949,8 +1033,11 @@ extern "C" const char* tebako_get_archive_path(void)
     return nullptr;
   }
 
-  const std::string& path = g_filesystem->archive_path();
-  return path.empty() ? nullptr : path.c_str();
+  // Store in static to ensure lifetime (thread-safe with lock);
+  // archive_path() returns std::string by value
+  static std::string cached_path;
+  cached_path = g_filesystem->archive_path();
+  return cached_path.empty() ? nullptr : cached_path.c_str();
 }
 
 extern "C" const char* tebako_get_backend_name(void)

--- a/tests/test_c_api.cpp
+++ b/tests/test_c_api.cpp
@@ -878,3 +878,196 @@ TEST_F(CApiTest, Integration_FullWorkflow)
   tebako_fs_unmount();
   EXPECT_EQ(0, tebako_is_initialized());
 }
+
+// ============================================================
+// Offset Mount Tests (tebako_fs_init_from_file_at)
+// ============================================================
+
+/**
+ * @brief Test fixture for tebako_fs_init_from_file_at()
+ *
+ * Builds a combined file: N bytes of junk followed by the bytes of the
+ * tests/fixtures/dwarfs/simple.dwarfs image, i.e. a DwarFS image embedded
+ * at offset N inside a larger file.
+ *
+ * NOTE: Shares the global C API state; serialized via RESOURCE_LOCK like the
+ * other test_c_api tests.
+ */
+class CApiOffsetTest : public ::testing::Test {
+ protected:
+  std::string test_dir;
+  std::string mount_point;
+  std::string plain_image_path;  // tests/fixtures/dwarfs/simple.dwarfs
+  std::string combined_path;     // junk + image
+  std::vector<char> image;       // bytes of simple.dwarfs
+  static constexpr uint64_t kJunkSize = 1000;
+
+  void SetUp() override
+  {
+    test_dir = (fs::temp_directory_path() / "tebako_c_api_offset_test").generic_string();
+    fs::create_directories(test_dir);
+    mount_point = "/__tebako_offset_test__";
+
+    // Fixture images are copied next to the test binaries at configure time
+    plain_image_path = "tests/fixtures/dwarfs/simple.dwarfs";
+
+    std::ifstream ifs(plain_image_path, std::ios::binary | std::ios::ate);
+    ASSERT_TRUE(ifs.is_open()) << "Failed to open fixture: " << plain_image_path;
+    auto size = ifs.tellg();
+    ASSERT_GT(size, 0);
+    image.resize(static_cast<size_t>(size));
+    ifs.seekg(0);
+    ifs.read(image.data(), size);
+    ifs.close();
+
+    // Prepend kJunkSize bytes of junk (deliberately not a valid archive magic)
+    combined_path = test_dir + "/combined.bin";
+    std::ofstream ofs(combined_path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(ofs.is_open());
+    for (uint64_t i = 0; i < kJunkSize; ++i) {
+      char c = static_cast<char>('A' + (i * 7) % 26);
+      ofs.write(&c, 1);
+    }
+    ofs.write(image.data(), static_cast<std::streamsize>(image.size()));
+    ofs.close();
+    ASSERT_TRUE(fs::exists(combined_path));
+  }
+
+  void TearDown() override
+  {
+    tebako_fs_unmount();
+    if (fs::exists(test_dir)) {
+      fs::remove_all(test_dir);
+    }
+  }
+
+  std::string read_file_via_api(const std::string& path)
+  {
+    int fd = tebako_fs_open(path.c_str(), O_RDONLY);
+    if (fd < 0)
+      return "";
+
+    std::vector<char> buffer(4096);
+    ssize_t n = tebako_fs_read(fd, buffer.data(), buffer.size());
+    tebako_fs_close(fd);
+
+    if (n <= 0)
+      return "";
+    return std::string(buffer.data(), n);
+  }
+};
+
+TEST_F(CApiOffsetTest, OffsetMount_ExplicitLength_ReadsMatchPlainImage)
+{
+  // Reference content: mount the plain fixture image
+  ASSERT_EQ(0, tebako_fs_init_from_file(plain_image_path.c_str(), mount_point.c_str()));
+  std::string expected_hello = read_file_via_api(mount_point + "/hello.txt");
+  std::string expected_test = read_file_via_api(mount_point + "/test.txt");
+  ASSERT_FALSE(expected_hello.empty()) << "Fixture hello.txt unexpectedly empty";
+  ASSERT_FALSE(expected_test.empty()) << "Fixture test.txt unexpectedly empty";
+  struct stat expected_st;
+  ASSERT_EQ(0, tebako_fs_stat((mount_point + "/hello.txt").c_str(), &expected_st));
+  tebako_fs_unmount();
+
+  // Mount the same image embedded at offset kJunkSize with explicit length
+  ASSERT_EQ(0, tebako_fs_init_from_file_at(combined_path.c_str(), kJunkSize, static_cast<uint64_t>(image.size()),
+                                           mount_point.c_str()));
+  EXPECT_EQ(1, tebako_is_initialized());
+
+  const char* bn = tebako_get_backend_name();
+  ASSERT_NE(nullptr, bn);
+  EXPECT_EQ("DwarFS", std::string(bn));
+
+  // Reads from the offset mount must match the plain mount
+  EXPECT_EQ(expected_hello, read_file_via_api(mount_point + "/hello.txt"));
+  EXPECT_EQ(expected_test, read_file_via_api(mount_point + "/test.txt"));
+
+  struct stat st;
+  ASSERT_EQ(0, tebako_fs_stat((mount_point + "/hello.txt").c_str(), &st));
+  EXPECT_EQ(expected_st.st_size, st.st_size);
+}
+
+TEST_F(CApiOffsetTest, OffsetMount_LengthZeroMeansToEndOfFile)
+{
+  ASSERT_EQ(0, tebako_fs_init_from_file_at(combined_path.c_str(), kJunkSize, 0, mount_point.c_str()));
+  EXPECT_EQ(1, tebako_is_initialized());
+  EXPECT_FALSE(read_file_via_api(mount_point + "/hello.txt").empty());
+}
+
+TEST_F(CApiOffsetTest, OffsetMount_ZeroOffsetExplicitLength)
+{
+  // Region path with offset == 0 but explicit length (no trailing data)
+  ASSERT_EQ(0, tebako_fs_init_from_file_at(plain_image_path.c_str(), 0, static_cast<uint64_t>(image.size()),
+                                           mount_point.c_str()));
+  EXPECT_EQ(1, tebako_is_initialized());
+  EXPECT_FALSE(read_file_via_api(mount_point + "/hello.txt").empty());
+}
+
+TEST_F(CApiOffsetTest, OffsetMount_WholeFileDelegationStillWorks)
+{
+  // tebako_fs_init_from_file delegates to _at(0, 0): zero-copy whole-file mount
+  ASSERT_EQ(0, tebako_fs_init_from_file(plain_image_path.c_str(), mount_point.c_str()));
+  EXPECT_EQ(1, tebako_is_initialized());
+
+  const char* bn = tebako_get_backend_name();
+  ASSERT_NE(nullptr, bn);
+  EXPECT_EQ("DwarFS", std::string(bn));
+
+  // Whole-file mount keeps the archive path (unlike region mounts)
+  const char* ap = tebako_get_archive_path();
+  ASSERT_NE(nullptr, ap);
+  EXPECT_EQ(plain_image_path, std::string(ap));
+
+  EXPECT_FALSE(read_file_via_api(mount_point + "/hello.txt").empty());
+}
+
+TEST_F(CApiOffsetTest, OffsetPastEnd_Fails)
+{
+  uint64_t file_size = fs::file_size(combined_path);
+  EXPECT_EQ(-1, tebako_fs_init_from_file_at(combined_path.c_str(), file_size + 1, 0, mount_point.c_str()));
+  EXPECT_EQ(EINVAL, tebako_get_errno());
+  EXPECT_EQ(0, tebako_is_initialized());
+}
+
+TEST_F(CApiOffsetTest, OffsetAtEndEmptyRegion_Fails)
+{
+  uint64_t file_size = fs::file_size(combined_path);
+  EXPECT_EQ(-1, tebako_fs_init_from_file_at(combined_path.c_str(), file_size, 0, mount_point.c_str()));
+  EXPECT_EQ(EINVAL, tebako_get_errno());
+  EXPECT_EQ(0, tebako_is_initialized());
+}
+
+TEST_F(CApiOffsetTest, LengthOverflow_Fails)
+{
+  // offset + length extends past end of file by one byte
+  EXPECT_EQ(-1, tebako_fs_init_from_file_at(combined_path.c_str(), kJunkSize, static_cast<uint64_t>(image.size()) + 1,
+                                            mount_point.c_str()));
+  EXPECT_EQ(EINVAL, tebako_get_errno());
+  EXPECT_EQ(0, tebako_is_initialized());
+}
+
+TEST_F(CApiOffsetTest, NullPath_Fails)
+{
+  EXPECT_EQ(-1, tebako_fs_init_from_file_at(nullptr, kJunkSize, 0, mount_point.c_str()));
+  EXPECT_EQ(EINVAL, tebako_get_errno());
+}
+
+TEST_F(CApiOffsetTest, NullMountPoint_Fails)
+{
+  EXPECT_EQ(-1, tebako_fs_init_from_file_at(combined_path.c_str(), kJunkSize, 0, nullptr));
+  EXPECT_EQ(EINVAL, tebako_get_errno());
+}
+
+TEST_F(CApiOffsetTest, NonexistentFile_Fails)
+{
+  EXPECT_EQ(-1, tebako_fs_init_from_file_at((test_dir + "/no_such_file.bin").c_str(), 0, 1, mount_point.c_str()));
+  EXPECT_EQ(ENOENT, tebako_get_errno());
+  EXPECT_EQ(0, tebako_is_initialized());
+}
+
+TEST_F(CApiOffsetTest, DoubleInitStillFailsWithEEXIST)
+{
+  ASSERT_EQ(0, tebako_fs_init_from_file_at(combined_path.c_str(), kJunkSize, 0, mount_point.c_str()));
+  EXPECT_EQ(-1, tebako_fs_init_from_file_at(combined_path.c_str(), kJunkSize, 0, mount_point.c_str()));
+  EXPECT_EQ(EEXIST, tebako_get_errno());
+}


### PR DESCRIPTION
## Summary

Adds `tebako_fs_init_from_file_at(archive_path, offset, length, mount_point)` to the libtfs C API: mounts `length` bytes at byte `offset` of a file (`length == 0` = to end of file). This supports images embedded inside larger files — e.g. appended to an executable with a manifest trailer (Stage 3A) — without requiring callers to map the region themselves.

## Semantics

- `offset == 0 && length == 0`: zero-copy whole-file mount (unchanged behavior); `tebako_fs_init_from_file()` now delegates to `_at(path, 0, 0, mp)`
- Other regions: region is read into a libtfs-owned buffer that stays alive until `tebako_fs_unmount()` (backend mounts from memory)
- Errors: `EINVAL` for NULL args, offset past EOF, empty region, or `offset + length` overflow; `ENOENT` for missing file; `EEXIST` when already mounted

## Tests

- 11 new `CApiOffsetTest` cases: DwarFS fixture embedded behind 1000 junk bytes mounted by explicit length and by to-EOF, read/stat equivalence with the plain mount, delegation back-compat, and all error paths
- Full ctest green locally (macOS arm64): 391/391 (380 existing in this build config + 11 new)

## Also fixed

`tebako_get_archive_path()` returned a dangling `c_str()` pointer to a temporary `std::string` (interface returns by value); now cached in a static like `tebako_get_backend_name()`. Exposed by the new delegation test.