### PR TITLE
feat: tebakofs three-part package tooling (bundle/unbundle/reassemble/info + granular ops + mkimage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- tebakofs package tooling for tebako three-part packages (bootstrap + image slots + `tpkg` manifest trailer): `bundle`, `unbundle`, `reassemble`, `insert-image`, `remove-image`, `set-runtime`, `mkimage` (mkdwarfs wrapper; dwarfs only — the zip backend is read-only), and `tebakofs info` now detects and dumps a `tpkg` trailer while keeping archive-info behavior for plain image files.
 - Release pipeline: per-platform `libtfs-deps-<version>-<platform>.tar.gz` package carrying the exact transitive static libraries consumers link against (dwarfs reader set, flatbuffers, libzip, fmt, xxhash, zstd/lz4/lzma/brotli/z/bzip2, boost filesystem+chrono; plus OpenSSL on Linux/Windows — macOS consumers link brew/system OpenSSL) together with those ports' CMake package configs. A `libtfs` package plus the matching `libtfs-deps` package are fully self-contained: no vcpkg needed downstream.
 
 ## [0.12.6] - 2026-07-22

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1033,7 +1033,9 @@ endif(WITH_TESTS)
 add_executable(tebakofs
   "src/tebakofs_main.cpp"
   "src/cli/tebakofs.cpp"
+  "src/cli/package.cpp"
   "include/tebako/fs/cli/tebakofs.h"
+  "include/tebako/fs/cli/package.h"
 )
 
 target_include_directories(tebakofs PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1061,7 +1061,9 @@ add_executable(tebakofs
 
 target_include_directories(tebakofs PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/tebako/fs
+  # NOTE: do not add include/tebako/fs here — with that dir on the include
+  # path, `#include <io.h>` resolves to libtfs's own include/tebako/fs/io.h
+  # and shadows the system header MinGW needs for _read/_write (tpkg.h).
 )
 
 target_link_libraries(tebakofs PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1006,6 +1006,27 @@ if (WITH_TESTS)
   )
   gtest_add_tests(TARGET test_tpkg)
 
+  # tebakofs package tooling tests (bundle/unbundle/reassemble, granular ops,
+  # mkimage). Compiles the package module directly (no tfs link) and also
+  # exercises the built tebakofs binary end-to-end via subprocess.
+  add_executable(test_package
+    "tests/test_package.cpp"
+    "src/cli/package.cpp"
+  )
+  target_include_directories(test_package PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  target_link_libraries(test_package PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+  )
+  target_compile_definitions(test_package PRIVATE
+    TEBAKOFS_BINARY="$<TARGET_FILE:tebakofs>"
+    TEBAKO_TEST_MKDWARFS="${MKDWARFS}"
+  )
+  add_dependencies(test_package tebakofs)
+  gtest_add_tests(TARGET test_package)
+
   # Unified interface tests
   add_executable(test_unified_interface
     "tests/test_unified_interface.cpp"

--- a/README.adoc
+++ b/README.adoc
@@ -643,6 +643,39 @@ tebakofs help ls
 
 The CLI tool automatically detects archive format and selects the appropriate backend.
 
+=== Package tooling - three-part packages
+
+tebakofs also assembles and edits tebako "three-part packages" — a single
+executable composed of a bootstrap/runtime portion, one or more appended
+filesystem images (slots), and a `tpkg` manifest trailer at the end of the
+file (see `include/tebako/tpkg.h`):
+
+[source,bash]
+----
+# Assemble a package (bootstrap + images + manifest trailer)
+# Default mountpoint for image slot 0 is /__tebako_memfs__
+tebakofs bundle --bootstrap runtime --image app.dwarfs -o myapp
+tebakofs bundle --bootstrap runtime --image app.dwarfs:/app --image data.dwarfs:/data -o myapp
+
+# Dump the manifest trailer of an executable (slot table, validity)
+tebakofs info myapp
+
+# Decompose into bootstrap.bin, image-<N>.bin and manifest.json
+tebakofs unbundle myapp -o parts/
+
+# Rebuild (byte-identical when unchanged; picks up swapped parts)
+tebakofs reassemble parts/ -o myapp.patched
+
+# Granular part editing (rewrites the binary in place)
+tebakofs insert-image myapp extra.dwarfs:/extra
+tebakofs remove-image myapp 1
+tebakofs set-runtime myapp new-runtime
+
+# Create a dwarfs image (wraps mkdwarfs via TEBAKO_MKDWARFS or PATH;
+# only dwarfs is supported — the zip backend is read-only)
+tebakofs mkimage --format dwarfs app/ -o app.dwarfs
+----
+
 == Memory Mounting
 
 libtfs supports mounting archives directly from memory, enabling embedded executable use cases.

--- a/docs/TEBAKOFS_USAGE.md
+++ b/docs/TEBAKOFS_USAGE.md
@@ -158,6 +158,47 @@ cd build
 ./tebakofs help extract
 ```
 
+### 9. Package Tooling (three-part packages)
+
+tebakofs assembles and edits tebako "three-part packages" — a single
+executable composed of a bootstrap/runtime portion, one or more appended
+filesystem images (slots), and a `tpkg` manifest trailer at the end of the
+file (wire format: `include/tebako/tpkg.h`).
+
+```bash
+# Assemble a package (bootstrap + images + manifest trailer)
+./tebakofs bundle --bootstrap runtime --image app.dwarfs -o myapp
+./tebakofs bundle --bootstrap runtime --image app.dwarfs:/app --image data.dwarfs:/data -o myapp
+
+# Dump the manifest trailer of an executable
+./tebakofs info myapp
+
+# Decompose into bootstrap.bin, image-<N>.bin and manifest.json
+./tebakofs unbundle myapp -o parts/
+
+# Rebuild (byte-identical when nothing changed; picks up swapped parts)
+./tebakofs reassemble parts/ -o myapp.patched
+
+# Granular part editing (rewrites the binary in place)
+./tebakofs insert-image myapp extra.dwarfs:/extra
+./tebakofs remove-image myapp 1
+./tebakofs set-runtime myapp new-runtime
+
+# Create a dwarfs image from a directory (wraps mkdwarfs)
+./tebakofs mkimage --format dwarfs app/ -o app.dwarfs
+```
+
+**Notes:**
+- `bundle` defaults the mountpoint of image slot 0 to `/__tebako_memfs__`
+  (slot N: `/__tebako_memfs_N__`) and sniffs image formats from magic bytes.
+  Optional: `--runtime-ref <ref>`, `--lean`, `--launcher-abi <n>`.
+- `info` keeps its archive behavior for plain image files; the package dump
+  appears only when a tpkg trailer is present.
+- `remove-image` refuses to remove the last remaining slot (a manifest
+  requires at least one slot).
+- `mkimage` locates `mkdwarfs` via `TEBAKO_MKDWARFS` or PATH. Only the
+  dwarfs format is supported — the zip backend is read-only.
+
 ## Supported Archive Formats
 
 tebakofs auto-detects format from magic bytes and works with:

--- a/include/tebako/fs/cli/package.h
+++ b/include/tebako/fs/cli/package.h
@@ -1,0 +1,153 @@
+/**
+ * @file package.h
+ * @brief tebako three-part package (tpkg) tooling for the tebakofs CLI
+ *
+ * A tebako "three-part package" is a single executable file composed of:
+ *   (1) a bootstrap/runtime executable portion,
+ *   (2) one or more filesystem images (slots) appended to it,
+ *   (3) a tpkg manifest trailer at the very end describing the slots
+ *       (see include/tebako/tpkg.h for the wire format).
+ *
+ * This module implements the business logic behind the tebakofs package
+ * subcommands (bundle/unbundle/reassemble, insert-image/remove-image/
+ * set-runtime, mkimage). The CLI layer only parses arguments.
+ *
+ * Copyright (c) 2026 Ribose Inc.
+ * All rights reserved.
+ */
+
+#pragma once
+
+#include <tebako/tpkg.h>
+
+#include <cstdint>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace tebako {
+namespace fs {
+namespace cli {
+
+/**
+ * @brief Result of a package operation
+ */
+struct PackageResult {
+  bool ok = false;
+  std::string error;  // human-readable description when !ok
+};
+
+/**
+ * @brief Manifest trailer fields controlled by the caller (bundle/reassemble)
+ */
+struct PackageOptions {
+  std::string runtime_ref;     // empty = classic bundle (runtime embedded)
+  uint32_t package_flags = 0;  // TPKG_FLAG_* bits (e.g. TPKG_FLAG_LEAN)
+  uint32_t launcher_abi = 0;   // 0 = no launcher ABI spoken
+};
+
+/**
+ * @brief An image to pack into a package slot
+ */
+struct PackageImage {
+  std::string path;                       // image file on disk
+  std::string mount_point;                // empty = default mount for its slot index
+  uint32_t format_id = TPKG_FORMAT_AUTO;  // TPKG_FORMAT_AUTO = sniff magic
+};
+
+/**
+ * @brief Default mount point for an image slot
+ *
+ * Slot 0 mounts at "/__tebako_memfs__" (the tebako memfs root); additional
+ * slots default to "/__tebako_memfs_<N>__".
+ */
+std::string package_default_mount(uint32_t slot_index);
+
+/**
+ * @brief Parse a CLI image specification "<img[:mountpoint]>"
+ *
+ * The mountpoint must be absolute (start with '/'); a ':' not followed by
+ * '/' is treated as part of the file name (e.g. Windows drive letters).
+ */
+PackageImage package_parse_image_spec(const std::string& spec);
+
+/**
+ * @brief Read the tpkg manifest trailer of a binary
+ *
+ * @param binary Path to the candidate package file
+ * @param out Manifest (valid only when true is returned)
+ * @param tpkg_err TPKG_ERR_* code when false is returned; TPKG_ERR_NO_TRAILER
+ *        means the file simply has no trailer (not a three-part package)
+ * @return true if a valid manifest was read
+ */
+bool package_probe(const std::string& binary, tpkg_manifest& out, int& tpkg_err);
+
+/**
+ * @brief Assemble a three-part binary: bootstrap bytes, image slots, trailer
+ *
+ * Layout: [bootstrap][image 0]...[image n-1][slot table][trailer header].
+ * Images are written contiguously in the order given.
+ */
+PackageResult package_bundle(const std::string& bootstrap,
+                             const std::vector<PackageImage>& images,
+                             const std::string& output,
+                             const PackageOptions& options);
+
+/**
+ * @brief Decompose a three-part binary into a directory
+ *
+ * Writes <dir>/bootstrap.bin, <dir>/image-<N>.bin per slot and
+ * <dir>/manifest.json (slot table: offset, size, format, mountpoint, crc32).
+ * Byte ranges between parts that are covered by no slot (padding) are dropped
+ * with a warning.
+ */
+PackageResult package_unbundle(const std::string& binary, const std::string& output_dir);
+
+/**
+ * @brief Rebuild a binary from an unbundled directory
+ *
+ * Reads <dir>/manifest.json and the part files it references. Offsets and
+ * sizes are recomputed from the actual parts, so swapped/edited parts are
+ * picked up; with unchanged parts the result is byte-identical to the
+ * original bundled binary.
+ */
+PackageResult package_reassemble(const std::string& input_dir, const std::string& output);
+
+/**
+ * @brief Append an image slot to a package (rewrites the file in place)
+ *
+ * @param mount_point empty = default mount for the new slot index
+ */
+PackageResult package_insert_image(const std::string& binary, const std::string& image, const std::string& mount_point);
+
+/**
+ * @brief Remove an image slot from a package (rewrites the file in place)
+ *
+ * The last remaining slot cannot be removed (a manifest requires >= 1 slot).
+ */
+PackageResult package_remove_image(const std::string& binary, uint32_t slot_index);
+
+/**
+ * @brief Replace the bootstrap (executable) portion of a package
+ *
+ * For a classic stitched package this swaps the embedded runtime; for a lean
+ * package it swaps the bootstrap launcher. Images and trailer fields are
+ * preserved. Rewrites the file in place.
+ */
+PackageResult package_set_runtime(const std::string& binary, const std::string& runtime_file);
+
+/**
+ * @brief Create a filesystem image from a directory (wraps mkdwarfs)
+ *
+ * Only "dwarfs" is supported: the zip backend is read-only. The mkdwarfs
+ * binary is located via `tool` when non-empty, then the TEBAKO_MKDWARFS
+ * environment variable, then PATH.
+ */
+PackageResult package_mkimage(const std::string& format,
+                              const std::string& source_dir,
+                              const std::string& output,
+                              const std::string& tool);
+
+}  // namespace cli
+}  // namespace fs
+}  // namespace tebako

--- a/include/tebako/fs/cli/tebakofs.h
+++ b/include/tebako/fs/cli/tebakofs.h
@@ -35,6 +35,9 @@ struct CLIOptions {
   bool recursive = false;    // For ls -r
   bool long_format = false;  // For ls -l
   std::string dest_dir;      // For extract --dest
+  std::string runtime_ref;   // For bundle --runtime-ref
+  bool lean = false;         // For bundle --lean (TPKG_FLAG_LEAN)
+  int launcher_abi = 0;      // For bundle --launcher-abi
 };
 
 /**
@@ -108,6 +111,53 @@ class TebakofsCLI {
    * @brief Search for files matching pattern
    */
   int cmd_find(const std::string& archive, const std::string& pattern, const CLIOptions& opts);
+
+  /**
+   * @brief Assemble a three-part package (bootstrap + images + tpkg trailer)
+   *
+   * @param bootstrap Path to the bootstrap/runtime executable
+   * @param images Image specs "<img[:mountpoint]>" (at least one)
+   * @param output Output binary path
+   * @param opts Command options (runtime_ref, package_flags, launcher_abi)
+   * @return Exit code
+   */
+  int cmd_bundle(const std::string& bootstrap,
+                 const std::vector<std::string>& images,
+                 const std::string& output,
+                 const CLIOptions& opts);
+
+  /**
+   * @brief Decompose a three-part package into a directory
+   */
+  int cmd_unbundle(const std::string& binary, const std::string& output_dir, const CLIOptions& opts);
+
+  /**
+   * @brief Rebuild a binary from an unbundled directory
+   */
+  int cmd_reassemble(const std::string& input_dir, const std::string& output, const CLIOptions& opts);
+
+  /**
+   * @brief Append an image slot to a package (in place)
+   */
+  int cmd_insert_image(const std::string& binary, const std::string& image_spec, const CLIOptions& opts);
+
+  /**
+   * @brief Remove an image slot from a package (in place)
+   */
+  int cmd_remove_image(const std::string& binary, uint32_t slot_index, const CLIOptions& opts);
+
+  /**
+   * @brief Replace the bootstrap (executable) portion of a package (in place)
+   */
+  int cmd_set_runtime(const std::string& binary, const std::string& runtime_file, const CLIOptions& opts);
+
+  /**
+   * @brief Create a filesystem image from a directory (wraps mkdwarfs)
+   */
+  int cmd_mkimage(const std::string& format,
+                  const std::string& source_dir,
+                  const std::string& output,
+                  const CLIOptions& opts);
 
   /**
    * @brief Show help information

--- a/src/cli/package.cpp
+++ b/src/cli/package.cpp
@@ -1,0 +1,1238 @@
+/**
+ * @file package.cpp
+ * @brief Implementation of tebako three-part package (tpkg) tooling
+ *
+ * Copyright (c) 2026 Ribose Inc.
+ * All rights reserved.
+ */
+
+// The tpkg.h implementation section lives in this translation unit. Per the
+// tpkg.h usage notes it must be included before any system header in this TU
+// (it defines _POSIX_C_SOURCE itself when needed).
+#define TPKG_IMPLEMENTATION
+#include <tebako/fs/cli/package.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <process.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace tebako {
+namespace fs {
+namespace cli {
+
+namespace {
+
+namespace fsys = std::filesystem;
+
+constexpr size_t kCopyBufferSize = 1u << 20;  // 1 MiB
+
+PackageResult fail(std::string msg)
+{
+  return PackageResult{false, std::move(msg)};
+}
+
+PackageResult success()
+{
+  return PackageResult{true, {}};
+}
+
+// ---- fd wrappers -----------------------------------------------------------
+
+int open_fd(const fsys::path& p, bool writable)
+{
+#ifdef _WIN32
+  return ::_open(p.string().c_str(), (writable ? _O_RDWR : _O_RDONLY) | _O_BINARY);
+#else
+  return ::open(p.string().c_str(), writable ? O_RDWR : O_RDONLY);
+#endif
+}
+
+void close_fd(int fd)
+{
+#ifdef _WIN32
+  ::_close(fd);
+#else
+  ::close(fd);
+#endif
+}
+
+int current_pid()
+{
+#ifdef _WIN32
+  return ::_getpid();
+#else
+  return ::getpid();
+#endif
+}
+
+// ---- streaming CRC-32 (zlib polynomial, identical to tpkg_crc32) -----------
+
+const uint32_t* crc32_table()
+{
+  static const uint32_t* table = [] {
+    auto* t = new uint32_t[256];
+    for (uint32_t i = 0; i < 256; i++) {
+      uint32_t c = i;
+      for (int k = 0; k < 8; k++) {
+        c = (c >> 1) ^ (0xEDB88320u & (0u - (c & 1u)));
+      }
+      t[i] = c;
+    }
+    return t;
+  }();
+  return table;
+}
+
+uint32_t crc32_update(uint32_t state, const void* data, size_t n)
+{
+  const uint32_t* table = crc32_table();
+  const auto* p = static_cast<const uint8_t*>(data);
+  for (size_t i = 0; i < n; i++) {
+    state = table[(state ^ p[i]) & 0xFFu] ^ (state >> 8);
+  }
+  return state;
+}
+
+// ---- part streaming ----------------------------------------------------------
+
+// A byte range of a file to copy into a package (length UINT64_MAX = to EOF).
+struct PartSource {
+  fsys::path path;
+  uint64_t offset = 0;
+  uint64_t length = UINT64_MAX;
+};
+
+struct SlotSource {
+  PartSource source;
+  uint32_t format_id = TPKG_FORMAT_AUTO;
+  uint32_t flags = 0;
+  std::string mount_point;
+};
+
+// Streams `source` into `out`; reports bytes written and (when crc_out is
+// non-null) the part's CRC-32. Returns false with `err` set on failure.
+bool stream_part(const PartSource& source, std::ofstream& out, uint64_t& written, uint32_t* crc_out, std::string& err)
+{
+  std::ifstream in(source.path, std::ios::binary);
+  if (!in) {
+    err = "cannot open part file: " + source.path.string();
+    return false;
+  }
+  in.seekg(0, std::ios::end);
+  auto file_size = static_cast<uint64_t>(in.tellg());
+  if (source.offset > file_size) {
+    err = "part offset " + std::to_string(source.offset) + " is beyond the end of file: " + source.path.string();
+    return false;
+  }
+  uint64_t available = file_size - source.offset;
+  uint64_t n = (source.length == UINT64_MAX) ? available : std::min(source.length, available);
+  in.seekg(static_cast<std::streamoff>(source.offset));
+
+  std::vector<char> buf(kCopyBufferSize);
+  uint32_t crc_state = 0xFFFFFFFFu;
+  uint64_t remaining = n;
+  while (remaining > 0) {
+    auto chunk = static_cast<size_t>(std::min<uint64_t>(remaining, buf.size()));
+    in.read(buf.data(), static_cast<std::streamsize>(chunk));
+    if (in.gcount() != static_cast<std::streamsize>(chunk)) {
+      err = "read failed: " + source.path.string();
+      return false;
+    }
+    out.write(buf.data(), static_cast<std::streamsize>(chunk));
+    if (!out) {
+      err = "write failed while streaming part: " + source.path.string();
+      return false;
+    }
+    crc_state = crc32_update(crc_state, buf.data(), chunk);
+    remaining -= chunk;
+  }
+  written = n;
+  if (crc_out) {
+    *crc_out = crc_state ^ 0xFFFFFFFFu;
+  }
+  return true;
+}
+
+// ---- image format sniffing ---------------------------------------------------
+
+uint32_t sniff_format(const fsys::path& path)
+{
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    return TPKG_FORMAT_AUTO;
+  }
+  unsigned char magic[8] = {0};
+  in.read(reinterpret_cast<char*>(magic), sizeof magic);
+  std::streamsize got = in.gcount();
+  if (got >= 6 && std::memcmp(magic, "DWARFS", 6) == 0) {
+    return TPKG_FORMAT_DWARFS;
+  }
+  if (got >= 4 && std::memcmp(magic, "hsqs", 4) == 0) {
+    return TPKG_FORMAT_SQUASHFS;
+  }
+  if (got >= 4 && (std::memcmp(magic, "PK\x03\x04", 4) == 0 || std::memcmp(magic, "PK\x05\x06", 4) == 0)) {
+    return TPKG_FORMAT_ZIP;
+  }
+  return TPKG_FORMAT_AUTO;
+}
+
+const char* format_name(uint32_t format_id)
+{
+  switch (format_id) {
+    case TPKG_FORMAT_DWARFS:
+      return "dwarfs";
+    case TPKG_FORMAT_SQUASHFS:
+      return "squashfs";
+    case TPKG_FORMAT_ZIP:
+      return "zip";
+    default:
+      return "auto";
+  }
+}
+
+// ---- assemble core -----------------------------------------------------------
+
+PackageResult assemble(const PartSource& bootstrap,
+                       const std::vector<SlotSource>& slots,
+                       const std::string& output,
+                       const PackageOptions& options)
+{
+  if (slots.empty() || slots.size() > TPKG_MAX_SLOTS) {
+    return fail("slot count out of range (1.." + std::to_string(TPKG_MAX_SLOTS) + ")");
+  }
+  if (options.runtime_ref.size() >= TPKG_RUNTIME_REF_LEN) {
+    return fail("runtime_ref is too long (max " + std::to_string(TPKG_RUNTIME_REF_LEN - 1) + " characters)");
+  }
+  for (const auto& s : slots) {
+    if (s.mount_point.size() >= TPKG_MOUNT_POINT_LEN) {
+      return fail("mount point is too long (max " + std::to_string(TPKG_MOUNT_POINT_LEN - 1) +
+                  " characters): " + s.mount_point);
+    }
+  }
+
+  // Refuse to clobber an input part
+  fsys::path out_canon = fsys::weakly_canonical(output);
+  auto clashes = [&out_canon](const fsys::path& p) { return fsys::weakly_canonical(p) == out_canon; };
+  if (clashes(bootstrap.path)) {
+    return fail("output path must differ from the bootstrap file: " + bootstrap.path.string());
+  }
+  for (const auto& s : slots) {
+    if (s.source.path != bootstrap.path && clashes(s.source.path)) {
+      return fail("output path must differ from the image file: " + s.source.path.string());
+    }
+  }
+
+  tpkg_manifest m{};
+  m.version = TPKG_VERSION;
+  m.package_flags = options.package_flags;
+  m.slot_count = static_cast<uint32_t>(slots.size());
+  m.launcher_abi = options.launcher_abi;
+  std::strncpy(m.runtime_ref, options.runtime_ref.c_str(), TPKG_RUNTIME_REF_LEN - 1);
+
+  {
+    std::ofstream out(output, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      return fail("cannot create output file: " + output);
+    }
+    std::string err;
+    uint64_t written = 0;
+    uint64_t total = 0;
+    if (!stream_part(bootstrap, out, written, nullptr, err)) {
+      out.close();
+      fsys::remove(output);
+      return fail(err);
+    }
+    total += written;
+    for (size_t i = 0; i < slots.size(); i++) {
+      written = 0;
+      if (!stream_part(slots[i].source, out, written, nullptr, err)) {
+        out.close();
+        fsys::remove(output);
+        return fail(err);
+      }
+      m.slots[i].offset = total;
+      m.slots[i].size = written;
+      m.slots[i].format_id = slots[i].format_id;
+      m.slots[i].flags = slots[i].flags;
+      std::strncpy(m.slots[i].mount_point, slots[i].mount_point.c_str(), TPKG_MOUNT_POINT_LEN - 1);
+      total += written;
+    }
+    out.flush();
+    if (!out) {
+      out.close();
+      fsys::remove(output);
+      return fail("write failed: " + output);
+    }
+  }
+
+  int fd = open_fd(output, true);
+  if (fd < 0) {
+    fsys::remove(output);
+    return fail("cannot open output file for trailer write: " + output);
+  }
+  int rc = tpkg_write_fd(fd, &m);
+  int terr = tpkg_errno();
+  close_fd(fd);
+  if (rc != 0) {
+    fsys::remove(output);
+    return fail(std::string("tpkg trailer write failed: ") + tpkg_strerror(terr));
+  }
+  return success();
+}
+
+PackageResult require_manifest(const std::string& binary, tpkg_manifest& m)
+{
+  int terr = 0;
+  if (!package_probe(binary, m, terr)) {
+    if (terr == TPKG_ERR_NO_TRAILER) {
+      return fail(binary + ": no tpkg manifest trailer present (not a three-part package)");
+    }
+    if (terr == TPKG_ERR_IO) {
+      return fail(binary + ": cannot read file");
+    }
+    return fail(binary + ": " + tpkg_strerror(terr));
+  }
+  return success();
+}
+
+// Rewrites `binary` from new part sources; the original is replaced (keeping
+// its permissions) only after the new file has been written completely.
+PackageResult rewrite_in_place(const std::string& binary,
+                               const PartSource& bootstrap,
+                               const std::vector<SlotSource>& slots,
+                               const PackageOptions& options)
+{
+  std::error_code ec;
+  auto perms = fsys::status(binary, ec).permissions();
+
+  static int counter = 0;
+  fsys::path tmp = fsys::path(binary).parent_path() / (fsys::path(binary).filename().string() + ".tpkg-tmp-" +
+                                                       std::to_string(current_pid()) + "-" + std::to_string(counter++));
+
+  auto res = assemble(bootstrap, slots, tmp.string(), options);
+  if (!res.ok) {
+    return res;
+  }
+  if (!ec) {
+    fsys::permissions(tmp, perms, ec);
+  }
+  fsys::rename(tmp, binary, ec);
+  if (ec) {
+    // Windows cannot rename over an existing file
+    std::error_code ec2;
+    fsys::remove(binary, ec2);
+    ec.clear();
+    fsys::rename(tmp, binary, ec);
+  }
+  if (ec) {
+    fsys::remove(tmp, ec);
+    return fail("cannot replace " + binary + " with the rewritten package");
+  }
+  return success();
+}
+
+// Slot sources pointing at the byte ranges of an existing package binary.
+std::vector<SlotSource> slots_from_manifest(const std::string& binary, const tpkg_manifest& m)
+{
+  std::vector<SlotSource> slots;
+  for (uint32_t i = 0; i < m.slot_count; i++) {
+    SlotSource s;
+    s.source = PartSource{binary, m.slots[i].offset, m.slots[i].size};
+    s.format_id = m.slots[i].format_id;
+    s.flags = m.slots[i].flags;
+    s.mount_point = m.slots[i].mount_point;
+    slots.push_back(std::move(s));
+  }
+  return slots;
+}
+
+PackageOptions options_from_manifest(const tpkg_manifest& m)
+{
+  PackageOptions opts;
+  opts.runtime_ref = m.runtime_ref;
+  opts.package_flags = m.package_flags;
+  opts.launcher_abi = m.launcher_abi;
+  return opts;
+}
+
+// ---- JSON writing ------------------------------------------------------------
+
+std::string json_escape(const std::string& s)
+{
+  std::string out;
+  for (char c : s) {
+    switch (c) {
+      case '"':
+        out += "\\\"";
+        break;
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\b':
+        out += "\\b";
+        break;
+      case '\f':
+        out += "\\f";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      case '\t':
+        out += "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          char buf[8];
+          std::snprintf(buf, sizeof buf, "\\u%04x", c);
+          out += buf;
+        }
+        else {
+          out += c;
+        }
+    }
+  }
+  return out;
+}
+
+// ---- minimal JSON parser (for manifest.json) ---------------------------------
+
+struct JsonValue {
+  enum Type { Null, Bool, Number, String, Array, Object };
+  Type type = Null;
+  bool boolean = false;
+  std::string str;                                         // String value, or raw Number text
+  std::vector<JsonValue> items;                            // Array
+  std::vector<std::pair<std::string, JsonValue>> members;  // Object
+
+  const JsonValue* find(const std::string& key) const
+  {
+    if (type != Object) {
+      return nullptr;
+    }
+    for (const auto& kv : members) {
+      if (kv.first == key) {
+        return &kv.second;
+      }
+    }
+    return nullptr;
+  }
+
+  bool as_u64(uint64_t& out) const
+  {
+    if (type != Number) {
+      return false;
+    }
+    char* end = nullptr;
+    unsigned long long v = std::strtoull(str.c_str(), &end, 10);
+    if (end == nullptr || *end != '\0') {
+      return false;
+    }
+    out = static_cast<uint64_t>(v);
+    return true;
+  }
+
+  bool as_string(std::string& out) const
+  {
+    if (type != String) {
+      return false;
+    }
+    out = str;
+    return true;
+  }
+};
+
+class JsonParser {
+ public:
+  explicit JsonParser(const std::string& text) : s_(text) {}
+
+  bool parse(JsonValue& out, std::string& err)
+  {
+    skip_ws();
+    if (!parse_value(out, err)) {
+      return false;
+    }
+    skip_ws();
+    if (pos_ != s_.size()) {
+      err = "trailing characters after JSON value";
+      return false;
+    }
+    return true;
+  }
+
+ private:
+  const std::string& s_;
+  size_t pos_ = 0;
+
+  void skip_ws()
+  {
+    while (pos_ < s_.size() && std::isspace(static_cast<unsigned char>(s_[pos_]))) {
+      pos_++;
+    }
+  }
+
+  bool expect(char c, std::string& err)
+  {
+    if (pos_ >= s_.size() || s_[pos_] != c) {
+      err = std::string("expected '") + c + "'";
+      return false;
+    }
+    pos_++;
+    return true;
+  }
+
+  bool parse_value(JsonValue& out, std::string& err)
+  {
+    skip_ws();
+    if (pos_ >= s_.size()) {
+      err = "unexpected end of input";
+      return false;
+    }
+    char c = s_[pos_];
+    if (c == '{') {
+      return parse_object(out, err);
+    }
+    if (c == '[') {
+      return parse_array(out, err);
+    }
+    if (c == '"') {
+      out.type = JsonValue::String;
+      return parse_string(out.str, err);
+    }
+    if (s_.compare(pos_, 4, "true") == 0) {
+      out.type = JsonValue::Bool;
+      out.boolean = true;
+      pos_ += 4;
+      return true;
+    }
+    if (s_.compare(pos_, 5, "false") == 0) {
+      out.type = JsonValue::Bool;
+      out.boolean = false;
+      pos_ += 5;
+      return true;
+    }
+    if (s_.compare(pos_, 4, "null") == 0) {
+      out.type = JsonValue::Null;
+      pos_ += 4;
+      return true;
+    }
+    if (c == '-' || (c >= '0' && c <= '9')) {
+      return parse_number(out, err);
+    }
+    err = "unexpected character in JSON input";
+    return false;
+  }
+
+  bool parse_object(JsonValue& out, std::string& err)
+  {
+    out.type = JsonValue::Object;
+    pos_++;  // '{'
+    skip_ws();
+    if (pos_ < s_.size() && s_[pos_] == '}') {
+      pos_++;
+      return true;
+    }
+    while (true) {
+      skip_ws();
+      std::string key;
+      if (!parse_string(key, err)) {
+        return false;
+      }
+      skip_ws();
+      if (!expect(':', err)) {
+        return false;
+      }
+      JsonValue val;
+      if (!parse_value(val, err)) {
+        return false;
+      }
+      out.members.emplace_back(std::move(key), std::move(val));
+      skip_ws();
+      if (pos_ < s_.size() && s_[pos_] == ',') {
+        pos_++;
+        continue;
+      }
+      if (pos_ < s_.size() && s_[pos_] == '}') {
+        pos_++;
+        return true;
+      }
+      err = "expected ',' or '}' in object";
+      return false;
+    }
+  }
+
+  bool parse_array(JsonValue& out, std::string& err)
+  {
+    out.type = JsonValue::Array;
+    pos_++;  // '['
+    skip_ws();
+    if (pos_ < s_.size() && s_[pos_] == ']') {
+      pos_++;
+      return true;
+    }
+    while (true) {
+      JsonValue val;
+      if (!parse_value(val, err)) {
+        return false;
+      }
+      out.items.push_back(std::move(val));
+      skip_ws();
+      if (pos_ < s_.size() && s_[pos_] == ',') {
+        pos_++;
+        continue;
+      }
+      if (pos_ < s_.size() && s_[pos_] == ']') {
+        pos_++;
+        return true;
+      }
+      err = "expected ',' or ']' in array";
+      return false;
+    }
+  }
+
+  bool parse_string(std::string& out, std::string& err)
+  {
+    if (!expect('"', err)) {
+      return false;
+    }
+    out.clear();
+    while (pos_ < s_.size()) {
+      char c = s_[pos_++];
+      if (c == '"') {
+        return true;
+      }
+      if (c == '\\') {
+        if (pos_ >= s_.size()) {
+          break;
+        }
+        char esc = s_[pos_++];
+        switch (esc) {
+          case '"':
+            out += '"';
+            break;
+          case '\\':
+            out += '\\';
+            break;
+          case '/':
+            out += '/';
+            break;
+          case 'b':
+            out += '\b';
+            break;
+          case 'f':
+            out += '\f';
+            break;
+          case 'n':
+            out += '\n';
+            break;
+          case 'r':
+            out += '\r';
+            break;
+          case 't':
+            out += '\t';
+            break;
+          case 'u': {
+            if (pos_ + 4 > s_.size()) {
+              err = "truncated \\u escape";
+              return false;
+            }
+            unsigned code = 0;
+            for (int i = 0; i < 4; i++) {
+              char h = s_[pos_++];
+              code <<= 4;
+              if (h >= '0' && h <= '9') {
+                code |= static_cast<unsigned>(h - '0');
+              }
+              else if (h >= 'a' && h <= 'f') {
+                code |= static_cast<unsigned>(h - 'a' + 10);
+              }
+              else if (h >= 'A' && h <= 'F') {
+                code |= static_cast<unsigned>(h - 'A' + 10);
+              }
+              else {
+                err = "invalid \\u escape";
+                return false;
+              }
+            }
+            if (code < 0x80) {
+              out += static_cast<char>(code);
+            }
+            else if (code < 0x800) {
+              out += static_cast<char>(0xC0 | (code >> 6));
+              out += static_cast<char>(0x80 | (code & 0x3F));
+            }
+            else {
+              out += static_cast<char>(0xE0 | (code >> 12));
+              out += static_cast<char>(0x80 | ((code >> 6) & 0x3F));
+              out += static_cast<char>(0x80 | (code & 0x3F));
+            }
+            break;
+          }
+          default:
+            err = "invalid escape sequence";
+            return false;
+        }
+      }
+      else {
+        out += c;
+      }
+    }
+    err = "unterminated string";
+    return false;
+  }
+
+  bool parse_number(JsonValue& out, std::string& err)
+  {
+    out.type = JsonValue::Number;
+    size_t start = pos_;
+    if (pos_ < s_.size() && s_[pos_] == '-') {
+      pos_++;
+    }
+    while (pos_ < s_.size() && (std::isdigit(static_cast<unsigned char>(s_[pos_])) || s_[pos_] == '.' ||
+                                s_[pos_] == 'e' || s_[pos_] == 'E' || s_[pos_] == '+' || s_[pos_] == '-')) {
+      pos_++;
+    }
+    if (pos_ == start) {
+      err = "invalid number";
+      return false;
+    }
+    out.str = s_.substr(start, pos_ - start);
+    return true;
+  }
+};
+
+// Reads a manifest member file name, rejecting paths that escape the
+// unbundled directory.
+bool safe_part_name(const std::string& name)
+{
+  fsys::path p(name);
+  return !name.empty() && p.filename().string() == name && name != "." && name != "..";
+}
+
+// ---- mkdwarfs invocation -----------------------------------------------------
+
+std::string shell_quote(const std::string& arg)
+{
+  std::string out = "\"";
+  for (char c : arg) {
+    if (c == '"' || c == '\\') {
+      out += '\\';
+    }
+    out += c;
+  }
+  out += "\"";
+  return out;
+}
+
+std::string find_on_path(const std::string& name)
+{
+  const char* path_env = std::getenv("PATH");
+  if (path_env == nullptr) {
+    return "";
+  }
+#ifdef _WIN32
+  const char sep = ';';
+  const std::vector<std::string> names = {name + ".exe", name};
+#else
+  const char sep = ':';
+  const std::vector<std::string> names = {name};
+#endif
+  std::string paths(path_env);
+  size_t start = 0;
+  while (start <= paths.size()) {
+    size_t end = paths.find(sep, start);
+    std::string dir = paths.substr(start, end == std::string::npos ? std::string::npos : end - start);
+    if (!dir.empty()) {
+      for (const auto& n : names) {
+        fsys::path cand = fsys::path(dir) / n;
+        std::error_code ec;
+        if (fsys::is_regular_file(cand, ec)) {
+#ifndef _WIN32
+          if (::access(cand.string().c_str(), X_OK) == 0) {
+            return cand.string();
+          }
+#else
+          return cand.string();
+#endif
+        }
+      }
+    }
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  return "";
+}
+
+}  // namespace
+
+// ---- public API --------------------------------------------------------------
+
+std::string package_default_mount(uint32_t slot_index)
+{
+  if (slot_index == 0) {
+    return "/__tebako_memfs__";
+  }
+  return "/__tebako_memfs_" + std::to_string(slot_index) + "__";
+}
+
+PackageImage package_parse_image_spec(const std::string& spec)
+{
+  PackageImage img;
+  auto colon = spec.find_last_of(':');
+  if (colon != std::string::npos && colon + 1 < spec.size() && spec[colon + 1] == '/') {
+    img.path = spec.substr(0, colon);
+    img.mount_point = spec.substr(colon + 1);
+  }
+  else {
+    img.path = spec;
+  }
+  return img;
+}
+
+bool package_probe(const std::string& binary, tpkg_manifest& out, int& tpkg_err)
+{
+  int fd = open_fd(binary, false);
+  if (fd < 0) {
+    tpkg_err = TPKG_ERR_IO;
+    return false;
+  }
+  int rc = tpkg_read_fd(fd, &out);
+  tpkg_err = tpkg_errno();
+  close_fd(fd);
+  return rc == 0;
+}
+
+PackageResult package_bundle(const std::string& bootstrap,
+                             const std::vector<PackageImage>& images,
+                             const std::string& output,
+                             const PackageOptions& options)
+{
+  if (images.empty() || images.size() > TPKG_MAX_SLOTS) {
+    return fail("image count out of range (1.." + std::to_string(TPKG_MAX_SLOTS) + ")");
+  }
+  std::error_code ec;
+  if (!fsys::is_regular_file(bootstrap, ec)) {
+    return fail("bootstrap file not found: " + bootstrap);
+  }
+  PartSource boot{bootstrap, 0, UINT64_MAX};
+
+  std::vector<SlotSource> slots;
+  for (size_t i = 0; i < images.size(); i++) {
+    if (!fsys::is_regular_file(images[i].path, ec)) {
+      return fail("image file not found: " + images[i].path);
+    }
+    SlotSource s;
+    s.source = PartSource{images[i].path, 0, UINT64_MAX};
+    s.format_id = images[i].format_id == TPKG_FORMAT_AUTO ? sniff_format(images[i].path) : images[i].format_id;
+    s.flags = 0;
+    s.mount_point =
+        images[i].mount_point.empty() ? package_default_mount(static_cast<uint32_t>(i)) : images[i].mount_point;
+    slots.push_back(std::move(s));
+  }
+  return assemble(boot, slots, output, options);
+}
+
+PackageResult package_unbundle(const std::string& binary, const std::string& output_dir)
+{
+  tpkg_manifest m;
+  auto res = require_manifest(binary, m);
+  if (!res.ok) {
+    return res;
+  }
+
+  std::error_code ec;
+  uint64_t total_size = fsys::file_size(binary, ec);
+  if (ec) {
+    return fail("cannot stat " + binary + ": " + ec.message());
+  }
+
+  // The manifest struct does not expose the raw header fields; re-read the
+  // fixed-size header for slot_table_offset / header_crc32 reporting.
+  uint64_t table_off = total_size - TPKG_HEADER_SIZE - static_cast<uint64_t>(m.slot_count) * TPKG_SLOT_SIZE;
+  uint32_t header_crc = 0;
+  {
+    std::ifstream in(binary, std::ios::binary);
+    if (!in) {
+      return fail("cannot open " + binary);
+    }
+    in.seekg(static_cast<std::streamoff>(total_size - TPKG_HEADER_SIZE));
+    uint8_t hdr[TPKG_HEADER_SIZE];
+    in.read(reinterpret_cast<char*>(hdr), sizeof hdr);
+    if (in.gcount() != static_cast<std::streamsize>(sizeof hdr)) {
+      return fail("cannot read trailer header of " + binary);
+    }
+    table_off = 0;
+    for (int i = 0; i < 8; i++) {
+      table_off |= static_cast<uint64_t>(hdr[22 + i]) << (8 * i);
+    }
+    header_crc = static_cast<uint32_t>(hdr[162]) | (static_cast<uint32_t>(hdr[163]) << 8) |
+                 (static_cast<uint32_t>(hdr[164]) << 16) | (static_cast<uint32_t>(hdr[165]) << 24);
+  }
+
+  // Slot ranges must lie entirely before the slot table.
+  for (uint32_t i = 0; i < m.slot_count; i++) {
+    if (m.slots[i].offset > table_off || m.slots[i].size > table_off - m.slots[i].offset) {
+      return fail("slot " + std::to_string(i) + " byte range is out of bounds (corrupt package)");
+    }
+  }
+  // The bootstrap is everything before slot 0.
+  uint64_t bootstrap_size = m.slot_count > 0 ? m.slots[0].offset : 0;
+
+  // Warn about byte ranges covered by no slot (dropped on reassemble).
+  uint64_t expected = bootstrap_size;
+  for (uint32_t i = 0; i < m.slot_count; i++) {
+    if (m.slots[i].offset > expected) {
+      std::cerr << "unbundle: warning: dropping " << (m.slots[i].offset - expected) << " gap byte(s) before slot " << i
+                << std::endl;
+    }
+    expected = m.slots[i].offset + m.slots[i].size;
+  }
+  if (expected < table_off) {
+    std::cerr << "unbundle: warning: dropping " << (table_off - expected) << " trailing gap byte(s)" << std::endl;
+  }
+
+  fsys::create_directories(output_dir, ec);
+  if (ec) {
+    return fail("cannot create output directory " + output_dir + ": " + ec.message());
+  }
+
+  // Stream the parts out, computing per-part checksums.
+  struct PartOut {
+    std::string file;
+    uint64_t size;
+    uint32_t crc;
+  };
+  std::vector<PartOut> parts;
+  auto stream_out = [&](const PartSource& src, const std::string& name) -> PackageResult {
+    fsys::path dest = fsys::path(output_dir) / name;
+    std::ofstream out(dest, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      return fail("cannot create part file: " + dest.string());
+    }
+    uint64_t written = 0;
+    uint32_t crc = 0;
+    std::string err;
+    if (!stream_part(src, out, written, &crc, err)) {
+      out.close();
+      fsys::remove(dest);
+      return fail(err);
+    }
+    out.close();
+    parts.push_back(PartOut{name, written, crc});
+    return success();
+  };
+
+  res = stream_out(PartSource{binary, 0, bootstrap_size}, "bootstrap.bin");
+  if (!res.ok) {
+    return res;
+  }
+  for (uint32_t i = 0; i < m.slot_count; i++) {
+    res = stream_out(PartSource{binary, m.slots[i].offset, m.slots[i].size}, "image-" + std::to_string(i) + ".bin");
+    if (!res.ok) {
+      return res;
+    }
+  }
+
+  // manifest.json (deterministic formatting; checksums via the tpkg CRC-32)
+  std::ostringstream json;
+  json << "{\n";
+  json << "  \"format\": \"tpkg\",\n";
+  json << "  \"format_version\": " << m.version << ",\n";
+  json << "  \"package_flags\": " << m.package_flags << ",\n";
+  json << "  \"launcher_abi\": " << m.launcher_abi << ",\n";
+  json << "  \"runtime_ref\": \"" << json_escape(m.runtime_ref) << "\",\n";
+  json << "  \"slot_table_offset\": " << table_off << ",\n";
+  json << "  \"header_crc32\": " << header_crc << ",\n";
+  json << "  \"bootstrap\": { \"file\": \"" << parts[0].file << "\", \"size\": " << parts[0].size
+       << ", \"crc32\": " << parts[0].crc << " },\n";
+  json << "  \"slots\": [\n";
+  for (uint32_t i = 0; i < m.slot_count; i++) {
+    const auto& p = parts[i + 1];
+    json << "    { \"index\": " << i << ", \"file\": \"" << p.file << "\", \"offset\": " << m.slots[i].offset
+         << ", \"size\": " << m.slots[i].size << ", \"format_id\": " << m.slots[i].format_id << ", \"format\": \""
+         << format_name(m.slots[i].format_id) << "\", \"flags\": " << m.slots[i].flags << ", \"mount_point\": \""
+         << json_escape(m.slots[i].mount_point) << "\", \"crc32\": " << p.crc << " }";
+    json << (i + 1 < m.slot_count ? ",\n" : "\n");
+  }
+  json << "  ]\n";
+  json << "}\n";
+
+  fsys::path manifest_path = fsys::path(output_dir) / "manifest.json";
+  {
+    std::ofstream out(manifest_path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+      return fail("cannot create " + manifest_path.string());
+    }
+    out << json.str();
+    if (!out) {
+      return fail("write failed: " + manifest_path.string());
+    }
+  }
+  return success();
+}
+
+PackageResult package_reassemble(const std::string& input_dir, const std::string& output)
+{
+  fsys::path dir = input_dir;
+  fsys::path manifest_path = dir / "manifest.json";
+  std::error_code ec;
+  if (!fsys::is_regular_file(manifest_path, ec)) {
+    return fail("manifest.json not found in " + input_dir + " (not an unbundled package directory)");
+  }
+  std::string text;
+  {
+    std::ifstream in(manifest_path, std::ios::binary);
+    if (!in) {
+      return fail("cannot read " + manifest_path.string());
+    }
+    text.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+  }
+
+  JsonValue root;
+  std::string err;
+  if (!JsonParser(text).parse(root, err)) {
+    return fail("cannot parse " + manifest_path.string() + ": " + err);
+  }
+  if (root.type != JsonValue::Object) {
+    return fail(manifest_path.string() + ": top-level value must be an object");
+  }
+  if (const JsonValue* fmt = root.find("format")) {
+    std::string f;
+    if (!fmt->as_string(f) || f != "tpkg") {
+      return fail(manifest_path.string() + ": unsupported format (expected \"tpkg\")");
+    }
+  }
+
+  PackageOptions opts;
+  uint64_t v = 0;
+  if (const JsonValue* f = root.find("package_flags")) {
+    if (!f->as_u64(v)) {
+      return fail(manifest_path.string() + ": package_flags must be an unsigned integer");
+    }
+    opts.package_flags = static_cast<uint32_t>(v);
+  }
+  if (const JsonValue* a = root.find("launcher_abi")) {
+    if (!a->as_u64(v)) {
+      return fail(manifest_path.string() + ": launcher_abi must be an unsigned integer");
+    }
+    opts.launcher_abi = static_cast<uint32_t>(v);
+  }
+  if (const JsonValue* r = root.find("runtime_ref")) {
+    if (!r->as_string(opts.runtime_ref)) {
+      return fail(manifest_path.string() + ": runtime_ref must be a string");
+    }
+  }
+
+  std::string bootstrap_name = "bootstrap.bin";
+  if (const JsonValue* b = root.find("bootstrap")) {
+    if (const JsonValue* f = b->find("file")) {
+      if (!f->as_string(bootstrap_name)) {
+        return fail(manifest_path.string() + ": bootstrap.file must be a string");
+      }
+    }
+  }
+  if (!safe_part_name(bootstrap_name)) {
+    return fail(manifest_path.string() + ": unsafe bootstrap file name: " + bootstrap_name);
+  }
+  fsys::path bootstrap_path = dir / bootstrap_name;
+  if (!fsys::is_regular_file(bootstrap_path, ec)) {
+    return fail("bootstrap part not found: " + bootstrap_path.string());
+  }
+
+  const JsonValue* slots_json = root.find("slots");
+  if (slots_json == nullptr || slots_json->type != JsonValue::Array || slots_json->items.empty() ||
+      slots_json->items.size() > TPKG_MAX_SLOTS) {
+    return fail(manifest_path.string() + ": slots must be an array of 1.." + std::to_string(TPKG_MAX_SLOTS) +
+                " entries");
+  }
+
+  std::vector<SlotSource> slots;
+  for (size_t i = 0; i < slots_json->items.size(); i++) {
+    const JsonValue& sj = slots_json->items[i];
+    std::string file;
+    const JsonValue* fj = sj.find("file");
+    if (fj == nullptr || !fj->as_string(file)) {
+      return fail(manifest_path.string() + ": slots[" + std::to_string(i) + "].file is required");
+    }
+    if (!safe_part_name(file)) {
+      return fail(manifest_path.string() + ": unsafe slot file name: " + file);
+    }
+    fsys::path part_path = dir / file;
+    if (!fsys::is_regular_file(part_path, ec)) {
+      return fail("slot part not found: " + part_path.string());
+    }
+
+    SlotSource s;
+    s.source = PartSource{part_path, 0, UINT64_MAX};
+    s.mount_point = package_default_mount(static_cast<uint32_t>(i));
+    s.format_id = sniff_format(part_path);
+    s.flags = 0;
+    if (const JsonValue* mp = sj.find("mount_point")) {
+      if (!mp->as_string(s.mount_point)) {
+        return fail(manifest_path.string() + ": slots[" + std::to_string(i) + "].mount_point must be a string");
+      }
+    }
+    if (const JsonValue* fi = sj.find("format_id")) {
+      if (!fi->as_u64(v)) {
+        return fail(manifest_path.string() + ": slots[" + std::to_string(i) +
+                    "].format_id must be an unsigned integer");
+      }
+      s.format_id = static_cast<uint32_t>(v);
+    }
+    if (const JsonValue* fl = sj.find("flags")) {
+      if (!fl->as_u64(v)) {
+        return fail(manifest_path.string() + ": slots[" + std::to_string(i) + "].flags must be an unsigned integer");
+      }
+      s.flags = static_cast<uint32_t>(v);
+    }
+    slots.push_back(std::move(s));
+  }
+
+  return assemble(PartSource{bootstrap_path, 0, UINT64_MAX}, slots, output, opts);
+}
+
+PackageResult package_insert_image(const std::string& binary, const std::string& image, const std::string& mount_point)
+{
+  tpkg_manifest m;
+  auto res = require_manifest(binary, m);
+  if (!res.ok) {
+    return res;
+  }
+  if (m.slot_count >= TPKG_MAX_SLOTS) {
+    return fail(binary + ": package already has the maximum of " + std::to_string(TPKG_MAX_SLOTS) + " image slots");
+  }
+  std::error_code ec;
+  if (!fsys::is_regular_file(image, ec)) {
+    return fail("image file not found: " + image);
+  }
+  if (fsys::weakly_canonical(image) == fsys::weakly_canonical(binary)) {
+    return fail("cannot insert the package into itself");
+  }
+
+  auto slots = slots_from_manifest(binary, m);
+  SlotSource s;
+  s.source = PartSource{image, 0, UINT64_MAX};
+  s.format_id = sniff_format(image);
+  s.flags = 0;
+  s.mount_point = mount_point.empty() ? package_default_mount(m.slot_count) : mount_point;
+  slots.push_back(std::move(s));
+
+  return rewrite_in_place(binary, PartSource{binary, 0, m.slots[0].offset}, slots, options_from_manifest(m));
+}
+
+PackageResult package_remove_image(const std::string& binary, uint32_t slot_index)
+{
+  tpkg_manifest m;
+  auto res = require_manifest(binary, m);
+  if (!res.ok) {
+    return res;
+  }
+  if (slot_index >= m.slot_count) {
+    return fail(binary + ": slot index " + std::to_string(slot_index) + " out of range (package has " +
+                std::to_string(m.slot_count) + " slot(s))");
+  }
+  if (m.slot_count == 1) {
+    return fail(binary + ": cannot remove the last image slot (a manifest requires at least one slot)");
+  }
+
+  auto slots = slots_from_manifest(binary, m);
+  slots.erase(slots.begin() + slot_index);
+
+  return rewrite_in_place(binary, PartSource{binary, 0, m.slots[0].offset}, slots, options_from_manifest(m));
+}
+
+PackageResult package_set_runtime(const std::string& binary, const std::string& runtime_file)
+{
+  tpkg_manifest m;
+  auto res = require_manifest(binary, m);
+  if (!res.ok) {
+    return res;
+  }
+  std::error_code ec;
+  if (!fsys::is_regular_file(runtime_file, ec)) {
+    return fail("runtime file not found: " + runtime_file);
+  }
+  if (fsys::weakly_canonical(runtime_file) == fsys::weakly_canonical(binary)) {
+    return fail("cannot use the package as its own runtime");
+  }
+
+  auto slots = slots_from_manifest(binary, m);
+  return rewrite_in_place(binary, PartSource{runtime_file, 0, UINT64_MAX}, slots, options_from_manifest(m));
+}
+
+PackageResult package_mkimage(const std::string& format,
+                              const std::string& source_dir,
+                              const std::string& output,
+                              const std::string& tool)
+{
+  std::string fmt;
+  for (char c : format) {
+    fmt += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  if (fmt == "zip") {
+    return fail("mkimage --format zip is not supported: the zip backend is read-only (only 'dwarfs' can be written)");
+  }
+  if (fmt == "squashfs") {
+    return fail("mkimage --format squashfs is not supported (LGPL; opt-in source builds only)");
+  }
+  if (fmt != "dwarfs") {
+    return fail("unsupported image format '" + format + "' (supported: dwarfs)");
+  }
+
+  std::error_code ec;
+  if (!fsys::is_directory(source_dir, ec)) {
+    return fail("source directory not found: " + source_dir);
+  }
+
+  std::string exe = tool;
+  if (exe.empty()) {
+    const char* env = std::getenv("TEBAKO_MKDWARFS");
+    if (env != nullptr && env[0] != '\0') {
+      exe = env;
+    }
+  }
+  if (exe.empty()) {
+    exe = find_on_path("mkdwarfs");
+  }
+  if (exe.empty()) {
+    return fail("mkdwarfs not found on PATH (install dwarfs or set TEBAKO_MKDWARFS)");
+  }
+  if (!fsys::is_regular_file(exe, ec)) {
+    return fail("mkdwarfs not found: " + exe);
+  }
+
+  std::string cmd =
+      shell_quote(exe) + " -i " + shell_quote(source_dir) + " -o " + shell_quote(output) + " --no-progress --force";
+  int rc = std::system(cmd.c_str());
+  if (rc != 0) {
+    return fail("mkdwarfs failed (exit code " + std::to_string(rc) + "): " + cmd);
+  }
+  if (!fsys::is_regular_file(output, ec)) {
+    return fail("mkdwarfs did not produce an output file: " + output);
+  }
+  return success();
+}
+
+}  // namespace cli
+}  // namespace fs
+}  // namespace tebako

--- a/src/cli/package.cpp
+++ b/src/cli/package.cpp
@@ -733,9 +733,13 @@ std::string shell_quote(const std::string& arg)
 {
   std::string out = "\"";
   for (char c : arg) {
+#ifndef _WIN32
+    // POSIX shells process backslash escapes inside double quotes; cmd.exe
+    // does not, and a Windows path separator must stay a single backslash
     if (c == '"' || c == '\\') {
       out += '\\';
     }
+#endif
     out += c;
   }
   out += "\"";
@@ -1221,8 +1225,20 @@ PackageResult package_mkimage(const std::string& format,
     return fail("mkdwarfs not found: " + exe);
   }
 
+  // Native-preferred separators for the CreateProcess/cmd.exe path handling
+  exe = fsys::path(exe).make_preferred().string();
+
   std::string cmd =
       shell_quote(exe) + " -i " + shell_quote(source_dir) + " -o " + shell_quote(output) + " --no-progress --force";
+#ifdef _WIN32
+  // std::system() goes through cmd.exe /c, which strips the first and last
+  // quote of a line that starts with one; with more than two quoted segments
+  // that mangles the line and cmd fails with ERROR_INVALID_NAME ("The
+  // filename, directory name, or volume label syntax is incorrect.") before
+  // mkdwarfs even starts. An extra outer pair of quotes survives the strip
+  // (the cmd /c ""exe" args" idiom).
+  cmd = "\"" + cmd + "\"";
+#endif
   int rc = std::system(cmd.c_str());
   if (rc != 0) {
     return fail("mkdwarfs failed (exit code " + std::to_string(rc) + "): " + cmd);

--- a/src/cli/tebakofs.cpp
+++ b/src/cli/tebakofs.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <tebako/fs/cli/tebakofs.h>
+#include <tebako/fs/cli/package.h>
 #include <tebako/fs/backend_factory.h>
 #include <tebako/fs/directory_iterator.h>
 #include <argtable3.h>
@@ -15,6 +16,7 @@
 #include <fstream>
 #include <sstream>
 #include <ctime>
+#include <filesystem>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -350,6 +352,188 @@ int TebakofsCLI::run(int argc, char* argv[])
     arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
     return 1;
   }
+  else if (command == "bundle") {
+    struct arg_lit* verbose = arg_lit0("v", "verbose", "verbose output");
+    struct arg_file* bootstrap = arg_file1(NULL, "bootstrap", "<exe>", "bootstrap/runtime executable");
+    struct arg_file* images =
+        arg_filen(NULL, "image", "<img[:mountpoint]>", 1, TPKG_MAX_SLOTS, "image files (repeatable)");
+    struct arg_file* output = arg_file1("o", "output", "<file>", "output binary");
+    struct arg_str* runtime_ref = arg_str0(NULL, "runtime-ref", "<ref>", "runtime reference for lean packages");
+    struct arg_lit* lean = arg_lit0(NULL, "lean", "mark the package as lean (bootstrap + images only)");
+    struct arg_int* abi = arg_int0(NULL, "launcher-abi", "<n>", "launcher ABI version (default: 0)");
+    struct arg_end* end = arg_end(20);
+
+    void* argtable[] = {verbose, bootstrap, images, output, runtime_ref, lean, abi, end};
+
+    int nerrors = arg_parse(argc - 1, argv + 1, argtable);
+
+    if (nerrors == 0) {
+      CLIOptions opts;
+      opts.verbose = verbose->count > 0;
+      opts.runtime_ref = runtime_ref->count > 0 ? runtime_ref->sval[0] : "";
+      opts.lean = lean->count > 0;
+      opts.launcher_abi = abi->count > 0 ? abi->ival[0] : 0;
+
+      std::vector<std::string> image_list;
+      for (int i = 0; i < images->count; i++) {
+        image_list.push_back(images->filename[i]);
+      }
+
+      int result = cmd_bundle(bootstrap->filename[0], image_list, output->filename[0], opts);
+
+      arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+      return result;
+    }
+
+    arg_print_errors(stderr, end, "tebakofs bundle");
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return 1;
+  }
+  else if (command == "unbundle") {
+    struct arg_lit* verbose = arg_lit0("v", "verbose", "verbose output");
+    struct arg_file* binary = arg_file1(NULL, NULL, "<binary>", "three-part package binary");
+    struct arg_file* output = arg_file1("o", "output", "<dir>", "output directory");
+    struct arg_end* end = arg_end(20);
+
+    void* argtable[] = {verbose, binary, output, end};
+
+    int nerrors = arg_parse(argc - 1, argv + 1, argtable);
+
+    if (nerrors == 0) {
+      CLIOptions opts;
+      opts.verbose = verbose->count > 0;
+
+      int result = cmd_unbundle(binary->filename[0], output->filename[0], opts);
+
+      arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+      return result;
+    }
+
+    arg_print_errors(stderr, end, "tebakofs unbundle");
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return 1;
+  }
+  else if (command == "reassemble") {
+    struct arg_lit* verbose = arg_lit0("v", "verbose", "verbose output");
+    struct arg_file* dir = arg_file1(NULL, NULL, "<dir>", "unbundled package directory");
+    struct arg_file* output = arg_file1("o", "output", "<file>", "output binary");
+    struct arg_end* end = arg_end(20);
+
+    void* argtable[] = {verbose, dir, output, end};
+
+    int nerrors = arg_parse(argc - 1, argv + 1, argtable);
+
+    if (nerrors == 0) {
+      CLIOptions opts;
+      opts.verbose = verbose->count > 0;
+
+      int result = cmd_reassemble(dir->filename[0], output->filename[0], opts);
+
+      arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+      return result;
+    }
+
+    arg_print_errors(stderr, end, "tebakofs reassemble");
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return 1;
+  }
+  else if (command == "insert-image") {
+    struct arg_lit* verbose = arg_lit0("v", "verbose", "verbose output");
+    struct arg_file* binary = arg_file1(NULL, NULL, "<binary>", "three-part package binary (rewritten in place)");
+    struct arg_file* image = arg_file1(NULL, NULL, "<img[:mountpoint]>", "image to append");
+    struct arg_end* end = arg_end(20);
+
+    void* argtable[] = {verbose, binary, image, end};
+
+    int nerrors = arg_parse(argc - 1, argv + 1, argtable);
+
+    if (nerrors == 0) {
+      CLIOptions opts;
+      opts.verbose = verbose->count > 0;
+
+      int result = cmd_insert_image(binary->filename[0], image->filename[0], opts);
+
+      arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+      return result;
+    }
+
+    arg_print_errors(stderr, end, "tebakofs insert-image");
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return 1;
+  }
+  else if (command == "remove-image") {
+    struct arg_lit* verbose = arg_lit0("v", "verbose", "verbose output");
+    struct arg_file* binary = arg_file1(NULL, NULL, "<binary>", "three-part package binary (rewritten in place)");
+    struct arg_int* slot = arg_int1(NULL, NULL, "<slot>", "slot index to remove");
+    struct arg_end* end = arg_end(20);
+
+    void* argtable[] = {verbose, binary, slot, end};
+
+    int nerrors = arg_parse(argc - 1, argv + 1, argtable);
+
+    if (nerrors == 0) {
+      CLIOptions opts;
+      opts.verbose = verbose->count > 0;
+
+      int result = cmd_remove_image(binary->filename[0], static_cast<uint32_t>(slot->ival[0]), opts);
+
+      arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+      return result;
+    }
+
+    arg_print_errors(stderr, end, "tebakofs remove-image");
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return 1;
+  }
+  else if (command == "set-runtime") {
+    struct arg_lit* verbose = arg_lit0("v", "verbose", "verbose output");
+    struct arg_file* binary = arg_file1(NULL, NULL, "<binary>", "three-part package binary (rewritten in place)");
+    struct arg_file* runtime = arg_file1(NULL, NULL, "<runtime-file>", "new bootstrap/runtime executable");
+    struct arg_end* end = arg_end(20);
+
+    void* argtable[] = {verbose, binary, runtime, end};
+
+    int nerrors = arg_parse(argc - 1, argv + 1, argtable);
+
+    if (nerrors == 0) {
+      CLIOptions opts;
+      opts.verbose = verbose->count > 0;
+
+      int result = cmd_set_runtime(binary->filename[0], runtime->filename[0], opts);
+
+      arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+      return result;
+    }
+
+    arg_print_errors(stderr, end, "tebakofs set-runtime");
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return 1;
+  }
+  else if (command == "mkimage") {
+    struct arg_lit* verbose = arg_lit0("v", "verbose", "verbose output");
+    struct arg_str* format = arg_str1(NULL, "format", "<format>", "image format (dwarfs)");
+    struct arg_file* srcdir = arg_file1(NULL, NULL, "<srcdir>", "source directory");
+    struct arg_file* output = arg_file1("o", "output", "<img>", "output image file");
+    struct arg_end* end = arg_end(20);
+
+    void* argtable[] = {verbose, format, srcdir, output, end};
+
+    int nerrors = arg_parse(argc - 1, argv + 1, argtable);
+
+    if (nerrors == 0) {
+      CLIOptions opts;
+      opts.verbose = verbose->count > 0;
+
+      int result = cmd_mkimage(format->sval[0], srcdir->filename[0], output->filename[0], opts);
+
+      arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+      return result;
+    }
+
+    arg_print_errors(stderr, end, "tebakofs mkimage");
+    arg_freetable(argtable, sizeof(argtable) / sizeof(argtable[0]));
+    return 1;
+  }
   else {
     std::cerr << "Error: Unknown command: " << command << std::endl;
     std::cerr << "Use 'tebakofs help' for usage information" << std::endl;
@@ -484,6 +668,56 @@ void TebakofsCLI::print_entry(const DirectoryEntry& entry, const std::string& pa
 
 int TebakofsCLI::cmd_info(const std::string& archive, const CLIOptions& opts)
 {
+  // A three-part package (bootstrap + images + tpkg trailer) is detected and
+  // dumped first; plain image files fall through to archive mounting below.
+  tpkg_manifest manifest;
+  int tpkg_err = 0;
+  if (package_probe(archive, manifest, tpkg_err)) {
+    std::error_code ec;
+    uint64_t total_size = std::filesystem::file_size(archive, ec);
+
+    std::cout << "Package: " << archive << std::endl;
+    std::cout << "Format: tebako three-part package (tpkg v" << manifest.version << ")" << std::endl;
+    if (!ec) {
+      std::cout << "Total size: " << format_size(static_cast<int64_t>(total_size)) << " (" << total_size << " bytes)"
+                << std::endl;
+    }
+    std::cout << "Flags: 0x" << std::hex << manifest.package_flags << std::dec;
+    if (manifest.package_flags & TPKG_FLAG_LEAN)
+      std::cout << " (LEAN)";
+    std::cout << std::endl;
+    std::cout << "Launcher ABI: " << manifest.launcher_abi << std::endl;
+    std::cout << "Runtime ref: " << (manifest.runtime_ref[0] ? manifest.runtime_ref : "(none — classic bundle)")
+              << std::endl;
+    std::cout << "Bootstrap size: " << manifest.slots[0].offset << " bytes" << std::endl;
+    std::cout << "Slots: " << manifest.slot_count << std::endl;
+    for (uint32_t i = 0; i < manifest.slot_count; i++) {
+      const tpkg_slot& s = manifest.slots[i];
+      std::cout << "  [" << i << "] offset=" << s.offset << " size=" << s.size << " format=";
+      switch (s.format_id) {
+        case TPKG_FORMAT_DWARFS:
+          std::cout << "dwarfs";
+          break;
+        case TPKG_FORMAT_SQUASHFS:
+          std::cout << "squashfs";
+          break;
+        case TPKG_FORMAT_ZIP:
+          std::cout << "zip";
+          break;
+        default:
+          std::cout << "auto";
+          break;
+      }
+      std::cout << " flags=" << s.flags << " mount=" << s.mount_point << std::endl;
+    }
+    std::cout << "Trailer: valid (magic and crc32 ok)" << std::endl;
+    return 0;
+  }
+  if (tpkg_err != TPKG_ERR_NO_TRAILER) {
+    std::cerr << "Error: " << archive << ": " << tpkg_strerror(tpkg_err) << std::endl;
+    return 1;
+  }
+
   auto fs = open_archive(archive);
   if (!fs)
     return 1;
@@ -860,6 +1094,114 @@ int TebakofsCLI::cmd_find(const std::string& archive, const std::string& pattern
   return 0;
 }
 
+int TebakofsCLI::cmd_bundle(const std::string& bootstrap,
+                            const std::vector<std::string>& images,
+                            const std::string& output,
+                            const CLIOptions& opts)
+{
+  std::vector<PackageImage> image_list;
+  for (const auto& spec : images) {
+    image_list.push_back(package_parse_image_spec(spec));
+  }
+
+  PackageOptions pkg_opts;
+  pkg_opts.runtime_ref = opts.runtime_ref;
+  pkg_opts.package_flags = opts.lean ? TPKG_FLAG_LEAN : 0;
+  pkg_opts.launcher_abi = opts.launcher_abi < 0 ? 0 : static_cast<uint32_t>(opts.launcher_abi);
+
+  auto res = package_bundle(bootstrap, image_list, output, pkg_opts);
+  if (!res.ok) {
+    std::cerr << "Error: bundle failed: " << res.error << std::endl;
+    return 1;
+  }
+  if (opts.verbose) {
+    std::cout << "Wrote package: " << output << " (" << image_list.size() << " image slot(s))" << std::endl;
+  }
+  return 0;
+}
+
+int TebakofsCLI::cmd_unbundle(const std::string& binary, const std::string& output_dir, const CLIOptions& opts)
+{
+  auto res = package_unbundle(binary, output_dir);
+  if (!res.ok) {
+    std::cerr << "Error: unbundle failed: " << res.error << std::endl;
+    return 1;
+  }
+  if (opts.verbose) {
+    std::cout << "Unbundled " << binary << " into: " << output_dir << std::endl;
+  }
+  return 0;
+}
+
+int TebakofsCLI::cmd_reassemble(const std::string& input_dir, const std::string& output, const CLIOptions& opts)
+{
+  auto res = package_reassemble(input_dir, output);
+  if (!res.ok) {
+    std::cerr << "Error: reassemble failed: " << res.error << std::endl;
+    return 1;
+  }
+  if (opts.verbose) {
+    std::cout << "Reassembled " << input_dir << " into: " << output << std::endl;
+  }
+  return 0;
+}
+
+int TebakofsCLI::cmd_insert_image(const std::string& binary, const std::string& image_spec, const CLIOptions& opts)
+{
+  auto image = package_parse_image_spec(image_spec);
+  auto res = package_insert_image(binary, image.path, image.mount_point);
+  if (!res.ok) {
+    std::cerr << "Error: insert-image failed: " << res.error << std::endl;
+    return 1;
+  }
+  if (opts.verbose) {
+    std::cout << "Inserted " << image.path << " into: " << binary << std::endl;
+  }
+  return 0;
+}
+
+int TebakofsCLI::cmd_remove_image(const std::string& binary, uint32_t slot_index, const CLIOptions& opts)
+{
+  auto res = package_remove_image(binary, slot_index);
+  if (!res.ok) {
+    std::cerr << "Error: remove-image failed: " << res.error << std::endl;
+    return 1;
+  }
+  if (opts.verbose) {
+    std::cout << "Removed slot " << slot_index << " from: " << binary << std::endl;
+  }
+  return 0;
+}
+
+int TebakofsCLI::cmd_set_runtime(const std::string& binary, const std::string& runtime_file, const CLIOptions& opts)
+{
+  auto res = package_set_runtime(binary, runtime_file);
+  if (!res.ok) {
+    std::cerr << "Error: set-runtime failed: " << res.error << std::endl;
+    return 1;
+  }
+  if (opts.verbose) {
+    std::cout << "Replaced the bootstrap portion of: " << binary << std::endl;
+  }
+  return 0;
+}
+
+int TebakofsCLI::cmd_mkimage(const std::string& format,
+                             const std::string& source_dir,
+                             const std::string& output,
+                             const CLIOptions& opts)
+{
+  auto res = package_mkimage(format, source_dir, output, "");
+  if (!res.ok) {
+    std::cerr << "Error: mkimage failed: " << res.error << std::endl;
+    return 1;
+  }
+  if (opts.verbose) {
+    std::cout << "Wrote " << format << " image: " << output << std::endl;
+  }
+  return 0;
+}
+
 int TebakofsCLI::cmd_help(const std::string& command)
 {
   if (command.empty()) {
@@ -867,12 +1209,19 @@ int TebakofsCLI::cmd_help(const std::string& command)
     std::cout << "Usage: tebakofs <command> [options] <archive> [args...]\n\n";
     std::cout << "Commands:\n";
     std::cout << "  ls       List directory contents\n";
-    std::cout << "  info     Show archive information\n";
+    std::cout << "  info     Show archive information (or dump a three-part package trailer)\n";
     std::cout << "  cat      Display file contents\n";
     std::cout << "  tree     Show directory tree\n";
     std::cout << "  stat     Show file/directory metadata\n";
     std::cout << "  extract  Extract archive contents\n";
     std::cout << "  find     Search for files\n";
+    std::cout << "  bundle        Assemble a three-part package (bootstrap + images + trailer)\n";
+    std::cout << "  unbundle      Decompose a three-part package into a directory\n";
+    std::cout << "  reassemble    Rebuild a binary from an unbundled directory\n";
+    std::cout << "  insert-image  Append an image slot to a package (in place)\n";
+    std::cout << "  remove-image  Remove an image slot from a package (in place)\n";
+    std::cout << "  set-runtime   Replace the bootstrap portion of a package (in place)\n";
+    std::cout << "  mkimage       Create a dwarfs image from a directory (wraps mkdwarfs)\n";
     std::cout << "  help     Show help for a command\n\n";
     std::cout << "Use 'tebakofs help <command>' for more information about a command.\n";
   }
@@ -899,6 +1248,83 @@ int TebakofsCLI::cmd_help(const std::string& command)
     std::cout << "  tebakofs extract archive.zip\n";
     std::cout << "  tebakofs extract archive.zip file1.txt file2.txt\n";
     std::cout << "  tebakofs extract -d /tmp/out archive.sqfs\n";
+  }
+  else if (command == "info") {
+    std::cout << "Usage: tebakofs info [options] <archive>\n\n";
+    std::cout << "Show archive information. When the file carries a tpkg manifest trailer\n";
+    std::cout << "(a tebako three-part package), the trailer is dumped instead: slot count,\n";
+    std::cout << "offsets, sizes, mountpoints and trailer validity.\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  -v, --verbose  Verbose output\n";
+  }
+  else if (command == "bundle") {
+    std::cout << "Usage: tebakofs bundle --bootstrap <exe> --image <img[:mountpoint]>... --output <file>\n\n";
+    std::cout << "Assemble a tebako three-part package: copy the bootstrap bytes, append each\n";
+    std::cout << "image as a slot, and write the tpkg manifest trailer. The default mountpoint\n";
+    std::cout << "for image slot 0 is /__tebako_memfs__ (slot N: /__tebako_memfs_N__); image\n";
+    std::cout << "formats are sniffed from magic bytes (dwarfs/squashfs/zip, else auto).\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --bootstrap <exe>        Bootstrap/runtime executable (required)\n";
+    std::cout << "  --image <img[:mount]>    Image file, repeatable (1.." << TPKG_MAX_SLOTS << ")\n";
+    std::cout << "  -o, --output <file>      Output binary (required)\n";
+    std::cout << "  --runtime-ref <ref>      Runtime reference recorded in the trailer\n";
+    std::cout << "  --lean                   Mark the package as lean (TPKG_FLAG_LEAN)\n";
+    std::cout << "  --launcher-abi <n>       Launcher ABI version (default: 0)\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  tebakofs bundle --bootstrap runtime --image app.dwarfs -o myapp\n";
+    std::cout << "  tebakofs bundle --bootstrap boot --image app.dwarfs:/app --image data.dwarfs:/data -o myapp\n";
+  }
+  else if (command == "unbundle") {
+    std::cout << "Usage: tebakofs unbundle <binary> --output <dir>\n\n";
+    std::cout << "Decompose a three-part package: writes bootstrap.bin, image-<N>.bin per slot\n";
+    std::cout << "and manifest.json (slot table: offset, size, format, mountpoint, crc32).\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  -o, --output <dir>  Output directory (required)\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  tebakofs unbundle myapp -o parts/\n";
+  }
+  else if (command == "reassemble") {
+    std::cout << "Usage: tebakofs reassemble <dir> --output <file>\n\n";
+    std::cout << "Rebuild a binary from an unbundled directory. With unchanged parts the result\n";
+    std::cout << "is byte-identical to the original; swapped or edited parts (and manifest.json\n";
+    std::cout << "metadata edits) are picked up and offsets/sizes recomputed.\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  -o, --output <file>  Output binary (required)\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  tebakofs reassemble parts/ -o myapp.patched\n";
+  }
+  else if (command == "insert-image") {
+    std::cout << "Usage: tebakofs insert-image <binary> <img[:mountpoint]>\n\n";
+    std::cout << "Append an image slot to a three-part package (rewrites the file in place).\n";
+    std::cout << "Default mountpoint: /__tebako_memfs_<N>__ for the new slot index N.\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  tebakofs insert-image myapp extra.dwarfs:/extra\n";
+  }
+  else if (command == "remove-image") {
+    std::cout << "Usage: tebakofs remove-image <binary> <slot>\n\n";
+    std::cout << "Remove an image slot from a three-part package (rewrites the file in place).\n";
+    std::cout << "The last remaining slot cannot be removed (a manifest requires >= 1 slot).\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  tebakofs remove-image myapp 1\n";
+  }
+  else if (command == "set-runtime") {
+    std::cout << "Usage: tebakofs set-runtime <binary> <runtime-file>\n\n";
+    std::cout << "Replace the bootstrap (executable) portion of a three-part package: for a\n";
+    std::cout << "classic stitched package this swaps the embedded runtime, for a lean package\n";
+    std::cout << "the bootstrap launcher. Images and trailer fields are preserved.\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  tebakofs set-runtime myapp tebako-runtime-3.3.7-macos-arm64\n";
+  }
+  else if (command == "mkimage") {
+    std::cout << "Usage: tebakofs mkimage --format dwarfs <srcdir> --output <img>\n\n";
+    std::cout << "Create a filesystem image from a directory. Thin wrapper around mkdwarfs,\n";
+    std::cout << "located via TEBAKO_MKDWARFS or PATH. Only the dwarfs format is supported:\n";
+    std::cout << "the zip backend is read-only.\n\n";
+    std::cout << "Options:\n";
+    std::cout << "  --format <format>   Image format: dwarfs (required)\n";
+    std::cout << "  -o, --output <img>  Output image file (required)\n\n";
+    std::cout << "Examples:\n";
+    std::cout << "  tebakofs mkimage --format dwarfs app/ -o app.dwarfs\n";
   }
   else {
     std::cout << "Use 'tebakofs help' for general help.\n";

--- a/tests/test_package.cpp
+++ b/tests/test_package.cpp
@@ -1,0 +1,844 @@
+/**
+ * @file test_package.cpp
+ * @brief Tests for tebakofs three-part package tooling (src/cli/package.cpp)
+ *
+ * Covers the golden round-trip (bundle -> unbundle -> reassemble identity),
+ * manifest.json contents, granular ops (insert-image/remove-image/set-runtime)
+ * and mkimage, both through the package API directly and end-to-end through
+ * the built tebakofs binary. Fixture binaries are small synthetic byte blobs
+ * (no real tebako runtimes).
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <process.h>
+#define popen _popen
+#define pclose _pclose
+#else
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#include <tebako/fs/cli/package.h>
+
+namespace {
+
+namespace fsys = std::filesystem;
+using tebako::fs::cli::PackageImage;
+using tebako::fs::cli::PackageOptions;
+using tebako::fs::cli::PackageResult;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+std::vector<uint8_t> Payload(size_t n, uint8_t seed = 7)
+{
+  std::vector<uint8_t> b(n);
+  for (size_t i = 0; i < n; i++) {
+    b[i] = static_cast<uint8_t>((i * 31 + seed) & 0xFF);
+  }
+  return b;
+}
+
+// Bytes that sniff as a dwarfs image (magic at offset 0)
+std::vector<uint8_t> Dwarfsish(size_t n)
+{
+  auto b = Payload(n, 41);
+  const char* magic = "DWARFS";
+  std::memcpy(b.data(), magic, 6);
+  return b;
+}
+
+std::vector<uint8_t> ReadFile(const fsys::path& p)
+{
+  std::ifstream in(p, std::ios::binary);
+  EXPECT_TRUE(in.good()) << "cannot open " << p;
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+void WriteFile(const fsys::path& p, const std::vector<uint8_t>& bytes)
+{
+  std::ofstream out(p, std::ios::binary | std::ios::trunc);
+  ASSERT_TRUE(out.good()) << "cannot create " << p;
+  out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+  ASSERT_TRUE(out.good()) << "cannot write " << p;
+}
+
+std::string ReadText(const fsys::path& p)
+{
+  std::ifstream in(p, std::ios::binary);
+  EXPECT_TRUE(in.good()) << "cannot open " << p;
+  return std::string(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+}
+
+class TempDir {
+ public:
+  explicit TempDir(const char* tag)
+  {
+    static int counter = 0;
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    path_ = fsys::temp_directory_path() /
+            ("pkg_test_" + std::string(info ? info->name() : "anon") + "_" + tag + "_" + std::to_string(counter++));
+    std::error_code ec;
+    fsys::create_directories(path_, ec);
+  }
+  ~TempDir()
+  {
+    std::error_code ec;
+    fsys::remove_all(path_, ec);
+  }
+  TempDir(const TempDir&) = delete;
+  TempDir& operator=(const TempDir&) = delete;
+  const fsys::path& path() const { return path_; }
+  fsys::path operator/(const std::string& name) const { return path_ / name; }
+
+ private:
+  fsys::path path_;
+};
+
+tpkg_manifest Probe(const fsys::path& binary)
+{
+  tpkg_manifest m{};
+  int terr = 0;
+  EXPECT_TRUE(tebako::fs::cli::package_probe(binary.string(), m, terr))
+      << "probe failed on " << binary << ": " << tpkg_strerror(terr);
+  return m;
+}
+
+void ExpectOk(const PackageResult& res)
+{
+  EXPECT_TRUE(res.ok) << res.error;
+}
+
+struct CliResult {
+  int exit_code = -1;
+  std::string output;
+};
+
+// Runs the built tebakofs binary (compile-time path) with the given arguments.
+CliResult RunCli(const std::string& args)
+{
+  std::string cmd = "\"" TEBAKOFS_BINARY "\" " + args + " 2>&1";
+  CliResult res;
+  FILE* pipe = popen(cmd.c_str(), "r");
+  if (!pipe) {
+    return res;
+  }
+  char buf[512];
+  while (fgets(buf, sizeof buf, pipe)) {
+    res.output += buf;
+  }
+  int status = pclose(pipe);
+#ifdef _WIN32
+  res.exit_code = status;
+#else
+  res.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#endif
+  return res;
+}
+
+std::string Q(const fsys::path& p)
+{
+  return "\"" + p.string() + "\"";
+}
+
+constexpr uint64_t kSlotSize = TPKG_SLOT_SIZE;
+constexpr uint64_t kHeaderSize = TPKG_HEADER_SIZE;
+
+}  // namespace
+
+// ============================================================================
+// image spec parsing
+// ============================================================================
+
+TEST(PackageSpec, Parse)
+{
+  auto plain = tebako::fs::cli::package_parse_image_spec("app.dwarfs");
+  EXPECT_EQ(plain.path, "app.dwarfs");
+  EXPECT_TRUE(plain.mount_point.empty());
+
+  auto with_mount = tebako::fs::cli::package_parse_image_spec("app.dwarfs:/app/data");
+  EXPECT_EQ(with_mount.path, "app.dwarfs");
+  EXPECT_EQ(with_mount.mount_point, "/app/data");
+
+  // ':' not followed by '/' stays part of the file name (Windows drives, relatives)
+  auto drive = tebako::fs::cli::package_parse_image_spec("C:\\images\\app.dwarfs");
+  EXPECT_EQ(drive.path, "C:\\images\\app.dwarfs");
+  EXPECT_TRUE(drive.mount_point.empty());
+}
+
+// ============================================================================
+// bundle
+// ============================================================================
+
+TEST(PackageBundle, BasicLayout)
+{
+  TempDir tmp("basic");
+  auto bootstrap = Payload(5000, 7);
+  auto img1 = Dwarfsish(3000);
+  auto img2 = Payload(4111, 99);
+  WriteFile(tmp / "boot.bin", bootstrap);
+  WriteFile(tmp / "i1.bin", img1);
+  WriteFile(tmp / "i2.bin", img2);
+
+  PackageOptions opts;
+  auto out = (tmp / "pkg.bin").string();
+  ExpectOk(tebako::fs::cli::package_bundle(
+      (tmp / "boot.bin").string(),
+      {PackageImage{(tmp / "i1.bin").string(), ""}, PackageImage{(tmp / "i2.bin").string(), ""}}, out, opts));
+
+  auto m = Probe(tmp / "pkg.bin");
+  ASSERT_EQ(m.slot_count, 2u);
+  EXPECT_EQ(m.slots[0].offset, 5000u);
+  EXPECT_EQ(m.slots[0].size, 3000u);
+  EXPECT_EQ(m.slots[0].format_id, TPKG_FORMAT_DWARFS) << "dwarfs magic must be sniffed";
+  EXPECT_STREQ(m.slots[0].mount_point, "/__tebako_memfs__");
+  EXPECT_EQ(m.slots[1].offset, 8000u);
+  EXPECT_EQ(m.slots[1].size, 4111u);
+  EXPECT_EQ(m.slots[1].format_id, TPKG_FORMAT_AUTO) << "unknown magic stays auto";
+  EXPECT_STREQ(m.slots[1].mount_point, "/__tebako_memfs_1__");
+
+  auto bytes = ReadFile(tmp / "pkg.bin");
+  ASSERT_EQ(bytes.size(), 5000u + 3000u + 4111u + 2 * kSlotSize + kHeaderSize);
+  EXPECT_EQ(0, std::memcmp(bytes.data(), bootstrap.data(), bootstrap.size())) << "bootstrap bytes at offset 0";
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 5000, img1.data(), img1.size())) << "image 0 follows the bootstrap";
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 8000, img2.data(), img2.size())) << "image 1 follows image 0";
+}
+
+TEST(PackageBundle, CustomOptionsRoundTrip)
+{
+  TempDir tmp("opts");
+  WriteFile(tmp / "boot.bin", Payload(100, 1));
+  WriteFile(tmp / "i1.bin", Payload(100, 2));
+
+  PackageOptions opts;
+  opts.runtime_ref = "ruby@3.3.7;tebako=0.15.0";
+  opts.package_flags = TPKG_FLAG_LEAN;
+  opts.launcher_abi = 1;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                           (tmp / "pkg.bin").string(), opts));
+
+  auto m = Probe(tmp / "pkg.bin");
+  EXPECT_EQ(m.version, TPKG_VERSION);
+  EXPECT_TRUE((m.package_flags & TPKG_FLAG_LEAN) != 0);
+  EXPECT_EQ(m.launcher_abi, 1u);
+  EXPECT_STREQ(m.runtime_ref, "ruby@3.3.7;tebako=0.15.0");
+}
+
+TEST(PackageBundle, ExplicitMountPointKept)
+{
+  TempDir tmp("mount");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(),
+                                           {PackageImage{(tmp / "i1.bin").string(), "/custom/mount"}},
+                                           (tmp / "pkg.bin").string(), opts));
+  auto m = Probe(tmp / "pkg.bin");
+  EXPECT_STREQ(m.slots[0].mount_point, "/custom/mount");
+}
+
+TEST(PackageBundle, NoImagesFails)
+{
+  TempDir tmp("noimg");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  PackageOptions opts;
+  auto res = tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {}, (tmp / "pkg.bin").string(), opts);
+  EXPECT_FALSE(res.ok);
+  EXPECT_FALSE(fsys::exists(tmp / "pkg.bin")) << "rejected bundle must not leave an output file";
+}
+
+TEST(PackageBundle, TooManyImagesFails)
+{
+  TempDir tmp("maximg");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i.bin", Payload(64, 2));
+  std::vector<PackageImage> images(TPKG_MAX_SLOTS + 1, PackageImage{(tmp / "i.bin").string(), ""});
+  PackageOptions opts;
+  auto res = tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), images, (tmp / "pkg.bin").string(), opts);
+  EXPECT_FALSE(res.ok);
+}
+
+TEST(PackageBundle, MissingBootstrapFails)
+{
+  TempDir tmp("noboot");
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+  PackageOptions opts;
+  auto res = tebako::fs::cli::package_bundle(
+      (tmp / "missing.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}}, (tmp / "pkg.bin").string(), opts);
+  EXPECT_FALSE(res.ok);
+}
+
+TEST(PackageBundle, OutputClobberingInputFails)
+{
+  TempDir tmp("clobber");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+  PackageOptions opts;
+  auto res = tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                             (tmp / "boot.bin").string(), opts);
+  EXPECT_FALSE(res.ok) << "output == bootstrap must be rejected";
+  EXPECT_EQ(ReadFile(tmp / "boot.bin"), Payload(64, 1)) << "input must be untouched";
+}
+
+// ============================================================================
+// golden round-trip: bundle -> unbundle -> reassemble == original
+// ============================================================================
+
+TEST(PackageRoundTrip, BundleUnbundleReassembleIdentity)
+{
+  TempDir tmp("golden");
+  auto bootstrap = Payload(5000, 7);
+  auto img1 = Dwarfsish(3000);
+  auto img2 = Payload(4111, 99);
+  WriteFile(tmp / "boot.bin", bootstrap);
+  WriteFile(tmp / "i1.bin", img1);
+  WriteFile(tmp / "i2.bin", img2);
+
+  PackageOptions opts;
+  opts.runtime_ref = "ruby@3.3.7;tebako=0.15.0";
+  opts.launcher_abi = 1;
+  ExpectOk(tebako::fs::cli::package_bundle(
+      (tmp / "boot.bin").string(),
+      {PackageImage{(tmp / "i1.bin").string(), ""}, PackageImage{(tmp / "i2.bin").string(), "/data"}},
+      (tmp / "pkg.bin").string(), opts));
+  auto original = ReadFile(tmp / "pkg.bin");
+
+  // unbundle
+  ExpectOk(tebako::fs::cli::package_unbundle((tmp / "pkg.bin").string(), (tmp / "parts").string()));
+  EXPECT_EQ(ReadFile(tmp / "parts" / "bootstrap.bin"), bootstrap);
+  EXPECT_EQ(ReadFile(tmp / "parts" / "image-0.bin"), img1);
+  EXPECT_EQ(ReadFile(tmp / "parts" / "image-1.bin"), img2);
+
+  // manifest.json contents
+  auto json = ReadText(tmp / "parts" / "manifest.json");
+  EXPECT_NE(json.find("\"format\": \"tpkg\""), std::string::npos);
+  EXPECT_NE(json.find("\"format_version\": 1"), std::string::npos);
+  EXPECT_NE(json.find("\"launcher_abi\": 1"), std::string::npos);
+  EXPECT_NE(json.find("\"runtime_ref\": \"ruby@3.3.7;tebako=0.15.0\""), std::string::npos);
+  EXPECT_NE(json.find("\"bootstrap\": { \"file\": \"bootstrap.bin\", \"size\": 5000"), std::string::npos);
+  EXPECT_NE(json.find("\"offset\": 5000"), std::string::npos);
+  EXPECT_NE(json.find("\"size\": 3000"), std::string::npos);
+  EXPECT_NE(json.find("\"format_id\": 1"), std::string::npos);
+  EXPECT_NE(json.find("\"format\": \"dwarfs\""), std::string::npos);
+  EXPECT_NE(json.find("\"mount_point\": \"/__tebako_memfs__\""), std::string::npos);
+  EXPECT_NE(json.find("\"mount_point\": \"/data\""), std::string::npos);
+  // per-part crc32 as computed by the tpkg crc
+  EXPECT_NE(json.find("\"crc32\": " + std::to_string(tpkg_crc32(img1.data(), img1.size()))), std::string::npos)
+      << "image-0 crc32 must match tpkg_crc32";
+  EXPECT_NE(json.find("\"crc32\": " + std::to_string(tpkg_crc32(bootstrap.data(), bootstrap.size()))),
+            std::string::npos)
+      << "bootstrap crc32 must match tpkg_crc32";
+
+  // reassemble -> byte-identical
+  ExpectOk(tebako::fs::cli::package_reassemble((tmp / "parts").string(), (tmp / "pkg2.bin").string()));
+  EXPECT_EQ(ReadFile(tmp / "pkg2.bin"), original) << "reassemble must be byte-identical when nothing changed";
+}
+
+TEST(PackageRoundTrip, ReassembleAfterImageSwap)
+{
+  TempDir tmp("swap");
+  auto bootstrap = Payload(5000, 7);
+  auto img1 = Dwarfsish(3000);
+  WriteFile(tmp / "boot.bin", bootstrap);
+  WriteFile(tmp / "i1.bin", img1);
+  WriteFile(tmp / "i2.bin", Payload(4111, 99));
+
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle(
+      (tmp / "boot.bin").string(),
+      {PackageImage{(tmp / "i1.bin").string(), ""}, PackageImage{(tmp / "i2.bin").string(), ""}},
+      (tmp / "pkg.bin").string(), opts));
+  ExpectOk(tebako::fs::cli::package_unbundle((tmp / "pkg.bin").string(), (tmp / "parts").string()));
+
+  // user swaps image-1 for a different image (different size)
+  auto img2_new = Payload(999, 55);
+  WriteFile(tmp / "parts" / "image-1.bin", img2_new);
+
+  ExpectOk(tebako::fs::cli::package_reassemble((tmp / "parts").string(), (tmp / "pkg2.bin").string()));
+  auto m = Probe(tmp / "pkg2.bin");
+  ASSERT_EQ(m.slot_count, 2u);
+  EXPECT_EQ(m.slots[0].offset, 5000u);
+  EXPECT_EQ(m.slots[0].size, 3000u);
+  EXPECT_EQ(m.slots[1].offset, 8000u) << "offsets recomputed";
+  EXPECT_EQ(m.slots[1].size, 999u) << "swapped size picked up";
+
+  auto bytes = ReadFile(tmp / "pkg2.bin");
+  ASSERT_EQ(bytes.size(), 5000u + 3000u + 999u + 2 * kSlotSize + kHeaderSize);
+  EXPECT_EQ(0, std::memcmp(bytes.data(), bootstrap.data(), bootstrap.size()));
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 5000, img1.data(), img1.size()));
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 8000, img2_new.data(), img2_new.size()));
+}
+
+TEST(PackageRoundTrip, ReassemblePicksUpManifestEdits)
+{
+  TempDir tmp("edit");
+  WriteFile(tmp / "boot.bin", Payload(128, 7));
+  WriteFile(tmp / "i1.bin", Payload(256, 8));
+
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                           (tmp / "pkg.bin").string(), opts));
+  ExpectOk(tebako::fs::cli::package_unbundle((tmp / "pkg.bin").string(), (tmp / "parts").string()));
+
+  // user edits manifest.json metadata
+  auto json = ReadText(tmp / "parts" / "manifest.json");
+  auto pos = json.find("/__tebako_memfs__");
+  ASSERT_NE(pos, std::string::npos);
+  json.replace(pos, std::strlen("/__tebako_memfs__"), "/edited/mount");
+  {
+    std::ofstream out(tmp / "parts" / "manifest.json", std::ios::binary | std::ios::trunc);
+    out << json;
+  }
+
+  ExpectOk(tebako::fs::cli::package_reassemble((tmp / "parts").string(), (tmp / "pkg2.bin").string()));
+  auto m = Probe(tmp / "pkg2.bin");
+  EXPECT_STREQ(m.slots[0].mount_point, "/edited/mount");
+}
+
+TEST(PackageRoundTrip, UnbundleNonPackageFails)
+{
+  TempDir tmp("nopkg");
+  WriteFile(tmp / "plain.bin", Payload(4096, 3));
+  auto res = tebako::fs::cli::package_unbundle((tmp / "plain.bin").string(), (tmp / "parts").string());
+  EXPECT_FALSE(res.ok);
+  EXPECT_NE(res.error.find("no tpkg manifest trailer"), std::string::npos);
+}
+
+TEST(PackageRoundTrip, ReassembleMissingManifestFails)
+{
+  TempDir tmp("nodir");
+  auto res = tebako::fs::cli::package_reassemble((tmp / "parts").string(), (tmp / "pkg.bin").string());
+  EXPECT_FALSE(res.ok);
+}
+
+// ============================================================================
+// insert-image
+// ============================================================================
+
+TEST(PackageInsert, AppendWithMount)
+{
+  TempDir tmp("ins");
+  auto bootstrap = Payload(5000, 7);
+  auto img1 = Dwarfsish(3000);
+  auto img2 = Payload(2000, 13);
+  WriteFile(tmp / "boot.bin", bootstrap);
+  WriteFile(tmp / "i1.bin", img1);
+  WriteFile(tmp / "i2.bin", img2);
+
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                           (tmp / "pkg.bin").string(), opts));
+
+  ExpectOk(tebako::fs::cli::package_insert_image((tmp / "pkg.bin").string(), (tmp / "i2.bin").string(), "/data"));
+
+  auto m = Probe(tmp / "pkg.bin");
+  ASSERT_EQ(m.slot_count, 2u);
+  EXPECT_EQ(m.slots[0].offset, 5000u);
+  EXPECT_EQ(m.slots[0].size, 3000u);
+  EXPECT_EQ(m.slots[1].offset, 8000u);
+  EXPECT_EQ(m.slots[1].size, 2000u);
+  EXPECT_STREQ(m.slots[1].mount_point, "/data");
+
+  auto bytes = ReadFile(tmp / "pkg.bin");
+  ASSERT_EQ(bytes.size(), 5000u + 3000u + 2000u + 2 * kSlotSize + kHeaderSize);
+  EXPECT_EQ(0, std::memcmp(bytes.data(), bootstrap.data(), bootstrap.size())) << "bootstrap preserved";
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 5000, img1.data(), img1.size())) << "slot 0 payload preserved";
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 8000, img2.data(), img2.size())) << "inserted payload present";
+}
+
+TEST(PackageInsert, DefaultMount)
+{
+  TempDir tmp("insdef");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+  WriteFile(tmp / "i2.bin", Payload(64, 3));
+
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                           (tmp / "pkg.bin").string(), opts));
+  ExpectOk(tebako::fs::cli::package_insert_image((tmp / "pkg.bin").string(), (tmp / "i2.bin").string(), ""));
+  auto m = Probe(tmp / "pkg.bin");
+  EXPECT_STREQ(m.slots[1].mount_point, "/__tebako_memfs_1__");
+}
+
+#ifndef _WIN32
+TEST(PackageInsert, PermissionsPreserved)
+{
+  TempDir tmp("insperm");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+  WriteFile(tmp / "i2.bin", Payload(64, 3));
+
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                           (tmp / "pkg.bin").string(), opts));
+  ASSERT_EQ(0, ::chmod((tmp / "pkg.bin").string().c_str(), 0755));
+  ExpectOk(tebako::fs::cli::package_insert_image((tmp / "pkg.bin").string(), (tmp / "i2.bin").string(), ""));
+  struct stat st;
+  ASSERT_EQ(0, ::stat((tmp / "pkg.bin").string().c_str(), &st));
+  EXPECT_EQ(st.st_mode & 0777, 0755) << "in-place rewrite must keep the executable bit";
+}
+#endif
+
+TEST(PackageInsert, NonPackageFails)
+{
+  TempDir tmp("insnp");
+  WriteFile(tmp / "plain.bin", Payload(4096, 3));
+  WriteFile(tmp / "i.bin", Payload(64, 2));
+  auto res = tebako::fs::cli::package_insert_image((tmp / "plain.bin").string(), (tmp / "i.bin").string(), "");
+  EXPECT_FALSE(res.ok);
+  EXPECT_NE(res.error.find("no tpkg manifest trailer"), std::string::npos);
+}
+
+TEST(PackageInsert, MaxSlotsFails)
+{
+  TempDir tmp("insmax");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i.bin", Payload(64, 2));
+  std::vector<PackageImage> images(TPKG_MAX_SLOTS, PackageImage{(tmp / "i.bin").string(), ""});
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), images, (tmp / "pkg.bin").string(), opts));
+
+  auto res = tebako::fs::cli::package_insert_image((tmp / "pkg.bin").string(), (tmp / "i.bin").string(), "");
+  EXPECT_FALSE(res.ok);
+}
+
+TEST(PackageInsert, SelfInsertFails)
+{
+  TempDir tmp("insself");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                           (tmp / "pkg.bin").string(), opts));
+  auto res = tebako::fs::cli::package_insert_image((tmp / "pkg.bin").string(), (tmp / "pkg.bin").string(), "");
+  EXPECT_FALSE(res.ok) << "inserting the package into itself must be rejected";
+}
+
+// ============================================================================
+// remove-image
+// ============================================================================
+
+TEST(PackageRemove, MiddleSlot)
+{
+  TempDir tmp("rm");
+  auto bootstrap = Payload(1000, 7);
+  auto img1 = Payload(100, 1);
+  auto img2 = Payload(200, 2);
+  auto img3 = Payload(300, 3);
+  WriteFile(tmp / "boot.bin", bootstrap);
+  WriteFile(tmp / "i1.bin", img1);
+  WriteFile(tmp / "i2.bin", img2);
+  WriteFile(tmp / "i3.bin", img3);
+
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle(
+      (tmp / "boot.bin").string(),
+      {PackageImage{(tmp / "i1.bin").string(), ""}, PackageImage{(tmp / "i2.bin").string(), "/two"},
+       PackageImage{(tmp / "i3.bin").string(), "/three"}},
+      (tmp / "pkg.bin").string(), opts));
+
+  ExpectOk(tebako::fs::cli::package_remove_image((tmp / "pkg.bin").string(), 1));
+
+  auto m = Probe(tmp / "pkg.bin");
+  ASSERT_EQ(m.slot_count, 2u);
+  EXPECT_EQ(m.slots[0].offset, 1000u);
+  EXPECT_EQ(m.slots[0].size, 100u);
+  EXPECT_EQ(m.slots[1].offset, 1100u) << "slots compacted";
+  EXPECT_EQ(m.slots[1].size, 300u);
+  EXPECT_STREQ(m.slots[1].mount_point, "/three") << "mount points travel with their slot";
+
+  auto bytes = ReadFile(tmp / "pkg.bin");
+  ASSERT_EQ(bytes.size(), 1000u + 100u + 300u + 2 * kSlotSize + kHeaderSize);
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 1000, img1.data(), img1.size()));
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 1100, img3.data(), img3.size()));
+}
+
+TEST(PackageRemove, LastSlotFails)
+{
+  TempDir tmp("rmlast");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle((tmp / "boot.bin").string(), {PackageImage{(tmp / "i1.bin").string(), ""}},
+                                           (tmp / "pkg.bin").string(), opts));
+  auto before = ReadFile(tmp / "pkg.bin");
+  auto res = tebako::fs::cli::package_remove_image((tmp / "pkg.bin").string(), 0);
+  EXPECT_FALSE(res.ok) << "the last slot cannot be removed";
+  EXPECT_EQ(ReadFile(tmp / "pkg.bin"), before) << "failed remove must leave the package untouched";
+}
+
+TEST(PackageRemove, OutOfRangeFails)
+{
+  TempDir tmp("rmoor");
+  WriteFile(tmp / "boot.bin", Payload(64, 1));
+  WriteFile(tmp / "i1.bin", Payload(64, 2));
+  WriteFile(tmp / "i2.bin", Payload(64, 3));
+  PackageOptions opts;
+  ExpectOk(tebako::fs::cli::package_bundle(
+      (tmp / "boot.bin").string(),
+      {PackageImage{(tmp / "i1.bin").string(), ""}, PackageImage{(tmp / "i2.bin").string(), ""}},
+      (tmp / "pkg.bin").string(), opts));
+  auto res = tebako::fs::cli::package_remove_image((tmp / "pkg.bin").string(), 5);
+  EXPECT_FALSE(res.ok);
+}
+
+// ============================================================================
+// set-runtime
+// ============================================================================
+
+TEST(PackageSetRuntime, SwapsBootstrap)
+{
+  TempDir tmp("setrt");
+  auto img1 = Dwarfsish(3000);
+  auto img2 = Payload(4111, 99);
+  auto runtime_new = Payload(777, 21);
+  WriteFile(tmp / "boot.bin", Payload(5000, 7));
+  WriteFile(tmp / "i1.bin", img1);
+  WriteFile(tmp / "i2.bin", img2);
+  WriteFile(tmp / "rt.bin", runtime_new);
+
+  PackageOptions opts;
+  opts.runtime_ref = "ruby@3.3.7;tebako=0.15.0";
+  ExpectOk(tebako::fs::cli::package_bundle(
+      (tmp / "boot.bin").string(),
+      {PackageImage{(tmp / "i1.bin").string(), ""}, PackageImage{(tmp / "i2.bin").string(), ""}},
+      (tmp / "pkg.bin").string(), opts));
+
+  ExpectOk(tebako::fs::cli::package_set_runtime((tmp / "pkg.bin").string(), (tmp / "rt.bin").string()));
+
+  auto m = Probe(tmp / "pkg.bin");
+  ASSERT_EQ(m.slot_count, 2u);
+  EXPECT_EQ(m.slots[0].offset, 777u) << "slot offsets shifted by the new bootstrap size";
+  EXPECT_EQ(m.slots[0].size, 3000u);
+  EXPECT_EQ(m.slots[1].offset, 777u + 3000u);
+  EXPECT_EQ(m.slots[1].size, 4111u);
+  EXPECT_STREQ(m.runtime_ref, "ruby@3.3.7;tebako=0.15.0") << "trailer fields preserved";
+
+  auto bytes = ReadFile(tmp / "pkg.bin");
+  ASSERT_EQ(bytes.size(), 777u + 3000u + 4111u + 2 * kSlotSize + kHeaderSize);
+  EXPECT_EQ(0, std::memcmp(bytes.data(), runtime_new.data(), runtime_new.size())) << "new runtime in place";
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 777, img1.data(), img1.size()));
+  EXPECT_EQ(0, std::memcmp(bytes.data() + 777 + 3000, img2.data(), img2.size()));
+}
+
+TEST(PackageSetRuntime, NonPackageFails)
+{
+  TempDir tmp("setnp");
+  WriteFile(tmp / "plain.bin", Payload(4096, 3));
+  WriteFile(tmp / "rt.bin", Payload(64, 1));
+  auto res = tebako::fs::cli::package_set_runtime((tmp / "plain.bin").string(), (tmp / "rt.bin").string());
+  EXPECT_FALSE(res.ok);
+}
+
+// ============================================================================
+// info (package_probe behavior on non-package files)
+// ============================================================================
+
+TEST(PackageInfo, PlainDwarfsImageHasNoTrailer)
+{
+  fsys::path fixture = "tests/fixtures/dwarfs/simple.dwarfs";
+  if (!fsys::exists(fixture)) {
+    GTEST_SKIP() << "fixture not generated: " << fixture;
+  }
+  tpkg_manifest m{};
+  int terr = 0;
+  EXPECT_FALSE(tebako::fs::cli::package_probe(fixture.string(), m, terr));
+  EXPECT_EQ(terr, TPKG_ERR_NO_TRAILER) << "a plain image must report 'no trailer', not an error";
+}
+
+TEST(PackageInfo, MissingFileIsIoError)
+{
+  tpkg_manifest m{};
+  int terr = 0;
+  EXPECT_FALSE(tebako::fs::cli::package_probe("/nonexistent/pkg.bin", m, terr));
+  EXPECT_EQ(terr, TPKG_ERR_IO);
+}
+
+// ============================================================================
+// mkimage
+// ============================================================================
+
+TEST(PackageMkimage, DwarfsViaExplicitTool)
+{
+  if (!fsys::exists(TEBAKO_TEST_MKDWARFS)) {
+    GTEST_SKIP() << "mkdwarfs not available at " << TEBAKO_TEST_MKDWARFS;
+  }
+  TempDir tmp("mkimg");
+  fsys::create_directories(tmp / "src" / "sub");
+  WriteFile(tmp / "src" / "hello.txt", {'h', 'e', 'l', 'l', 'o'});
+  WriteFile(tmp / "src" / "sub" / "data.bin", Payload(128, 5));
+
+  auto out = (tmp / "app.dwarfs").string();
+  ExpectOk(tebako::fs::cli::package_mkimage("dwarfs", (tmp / "src").string(), out, TEBAKO_TEST_MKDWARFS));
+
+  auto bytes = ReadFile(tmp / "app.dwarfs");
+  ASSERT_GT(bytes.size(), 6u);
+  EXPECT_EQ(0, std::memcmp(bytes.data(), "DWARFS", 6)) << "output must be a dwarfs image";
+}
+
+TEST(PackageMkimage, ZipRejected)
+{
+  TempDir tmp("mkzip");
+  fsys::create_directories(tmp / "src");
+  auto res = tebako::fs::cli::package_mkimage("zip", (tmp / "src").string(), (tmp / "out.zip").string(), "");
+  EXPECT_FALSE(res.ok);
+  EXPECT_NE(res.error.find("read-only"), std::string::npos);
+}
+
+TEST(PackageMkimage, BadToolFails)
+{
+  TempDir tmp("mkbad");
+  fsys::create_directories(tmp / "src");
+  auto res = tebako::fs::cli::package_mkimage("dwarfs", (tmp / "src").string(), (tmp / "out.dwarfs").string(),
+                                              "/nonexistent/mkdwarfs");
+  EXPECT_FALSE(res.ok);
+}
+
+TEST(PackageMkimage, MissingSourceFails)
+{
+  TempDir tmp("mksrc");
+  auto res = tebako::fs::cli::package_mkimage("dwarfs", (tmp / "missing").string(), (tmp / "out.dwarfs").string(),
+                                              TEBAKO_TEST_MKDWARFS);
+  EXPECT_FALSE(res.ok);
+}
+
+// ============================================================================
+// end-to-end through the built tebakofs binary
+// ============================================================================
+
+TEST(PackageCli, BundleInfoUnbundleReassemble)
+{
+  TempDir tmp("e2e");
+  auto bootstrap = Payload(5000, 7);
+  auto img1 = Dwarfsish(3000);
+  auto img2 = Payload(4111, 99);
+  WriteFile(tmp / "boot.bin", bootstrap);
+  WriteFile(tmp / "i1.bin", img1);
+  WriteFile(tmp / "i2.bin", img2);
+
+  // bundle
+  auto r = RunCli("bundle --bootstrap " + Q(tmp / "boot.bin") + " --image " + Q(tmp / "i1.bin") + " --image " +
+                  Q(tmp / "i2.bin") + ":/data -o " + Q(tmp / "pkg.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  auto original = ReadFile(tmp / "pkg.bin");
+  ASSERT_EQ(original.size(), 5000u + 3000u + 4111u + 2 * kSlotSize + kHeaderSize);
+
+  // info dumps the trailer
+  r = RunCli("info " + Q(tmp / "pkg.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  EXPECT_NE(r.output.find("three-part package"), std::string::npos);
+  EXPECT_NE(r.output.find("Slots: 2"), std::string::npos);
+  EXPECT_NE(r.output.find("offset=5000 size=3000"), std::string::npos);
+  EXPECT_NE(r.output.find("format=dwarfs"), std::string::npos);
+  EXPECT_NE(r.output.find("mount=/__tebako_memfs__"), std::string::npos);
+  EXPECT_NE(r.output.find("mount=/data"), std::string::npos);
+  EXPECT_NE(r.output.find("Trailer: valid"), std::string::npos);
+
+  // unbundle + reassemble -> byte-identical
+  r = RunCli("unbundle " + Q(tmp / "pkg.bin") + " -o " + Q(tmp / "parts"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  EXPECT_EQ(ReadFile(tmp / "parts" / "bootstrap.bin"), bootstrap);
+  EXPECT_EQ(ReadFile(tmp / "parts" / "image-0.bin"), img1);
+  EXPECT_EQ(ReadFile(tmp / "parts" / "image-1.bin"), img2);
+
+  r = RunCli("reassemble " + Q(tmp / "parts") + " -o " + Q(tmp / "pkg2.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  EXPECT_EQ(ReadFile(tmp / "pkg2.bin"), original);
+
+  // bundle without images is a usage error
+  r = RunCli("bundle --bootstrap " + Q(tmp / "boot.bin") + " -o " + Q(tmp / "pkg3.bin"));
+  EXPECT_NE(r.exit_code, 0);
+}
+
+TEST(PackageCli, InfoPlainDwarfsImageStillWorks)
+{
+  fsys::path fixture = "tests/fixtures/dwarfs/simple.dwarfs";
+  if (!fsys::exists(fixture)) {
+    GTEST_SKIP() << "fixture not generated: " << fixture;
+  }
+  auto r = RunCli("info " + fixture.string());
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  EXPECT_NE(r.output.find("Type: DwarFS"), std::string::npos);
+  EXPECT_NE(r.output.find("Files:"), std::string::npos) << "archive info path must be preserved";
+  EXPECT_EQ(r.output.find("three-part package"), std::string::npos);
+}
+
+TEST(PackageCli, GranularOps)
+{
+  TempDir tmp("e2eg");
+  WriteFile(tmp / "boot.bin", Payload(1000, 7));
+  WriteFile(tmp / "i1.bin", Dwarfsish(100));
+  WriteFile(tmp / "i2.bin", Payload(200, 2));
+  WriteFile(tmp / "rt.bin", Payload(555, 21));
+
+  auto r = RunCli("bundle --bootstrap " + Q(tmp / "boot.bin") + " --image " + Q(tmp / "i1.bin") + " -o " +
+                  Q(tmp / "pkg.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+
+  r = RunCli("insert-image " + Q(tmp / "pkg.bin") + " " + Q(tmp / "i2.bin") + ":/extra");
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  r = RunCli("info " + Q(tmp / "pkg.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  EXPECT_NE(r.output.find("Slots: 2"), std::string::npos);
+  EXPECT_NE(r.output.find("mount=/extra"), std::string::npos);
+
+  r = RunCli("remove-image " + Q(tmp / "pkg.bin") + " 0");
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  r = RunCli("info " + Q(tmp / "pkg.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  EXPECT_NE(r.output.find("Slots: 1"), std::string::npos);
+  EXPECT_NE(r.output.find("mount=/extra"), std::string::npos) << "remaining slot keeps its mount point";
+
+  r = RunCli("set-runtime " + Q(tmp / "pkg.bin") + " " + Q(tmp / "rt.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  r = RunCli("info " + Q(tmp / "pkg.bin"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  EXPECT_NE(r.output.find("Bootstrap size: 555 bytes"), std::string::npos);
+
+  // in-place ops on a non-package fail cleanly
+  WriteFile(tmp / "plain.bin", Payload(64, 1));
+  r = RunCli("insert-image " + Q(tmp / "plain.bin") + " " + Q(tmp / "i2.bin"));
+  EXPECT_NE(r.exit_code, 0);
+  EXPECT_NE(r.output.find("no tpkg manifest trailer"), std::string::npos);
+}
+
+TEST(PackageCli, MkimageViaEnv)
+{
+  if (!fsys::exists(TEBAKO_TEST_MKDWARFS)) {
+    GTEST_SKIP() << "mkdwarfs not available at " << TEBAKO_TEST_MKDWARFS;
+  }
+  TempDir tmp("e2emk");
+  fsys::create_directories(tmp / "src");
+  WriteFile(tmp / "src" / "hello.txt", {'h', 'i'});
+
+#ifdef _WIN32
+  _putenv(("TEBAKO_MKDWARFS=" + std::string(TEBAKO_TEST_MKDWARFS)).c_str());
+#else
+  setenv("TEBAKO_MKDWARFS", TEBAKO_TEST_MKDWARFS, 1);
+#endif
+  auto r = RunCli("mkimage --format dwarfs " + Q(tmp / "src") + " -o " + Q(tmp / "app.dwarfs"));
+  ASSERT_EQ(r.exit_code, 0) << r.output;
+  auto bytes = ReadFile(tmp / "app.dwarfs");
+  ASSERT_GT(bytes.size(), 6u);
+  EXPECT_EQ(0, std::memcmp(bytes.data(), "DWARFS", 6));
+
+  // zip is rejected with a clear message
+  r = RunCli("mkimage --format zip " + Q(tmp / "src") + " -o " + Q(tmp / "app.zip"));
+  EXPECT_NE(r.exit_code, 0);
+  EXPECT_NE(r.output.find("read-only"), std::string::npos);
+}

--- a/tests/test_package.cpp
+++ b/tests/test_package.cpp
@@ -130,7 +130,15 @@ struct CliResult {
 // Runs the built tebakofs binary (compile-time path) with the given arguments.
 CliResult RunCli(const std::string& args)
 {
-  std::string cmd = "\"" TEBAKOFS_BINARY "\" " + args + " 2>&1";
+  const std::string binary = fsys::path(TEBAKOFS_BINARY).make_preferred().string();
+  std::string cmd = "\"" + binary + "\" " + args + " 2>&1";
+#ifdef _WIN32
+  // popen goes through cmd.exe /c, which strips the first and last quote of a
+  // line that starts with one; with more than two quoted segments that mangles
+  // the line and cmd fails with ERROR_INVALID_NAME before tebakofs starts.
+  // An extra outer pair of quotes survives the strip (cmd /c ""exe" args").
+  cmd = "\"" + cmd + "\"";
+#endif
   CliResult res;
   FILE* pipe = popen(cmd.c_str(), "r");
   if (!pipe) {


### PR DESCRIPTION
## What

Implements Stage 3B-4 of the tebako master plan: tebakofs as the three-part package tool.

- **`tebakofs bundle --bootstrap <exe> --image <img[:mount]>... --output <file>`** — assemble a bootstrap + image slots + tpkg trailer binary. Image `format_id` sniffed from magic bytes; `--runtime-ref`/`--lean`/`--launcher-abi` optional.
- **`tebakofs unbundle <binary> --output <dir>`** — `bootstrap.bin`, `image-<N>.bin`, `manifest.json` (offsets, sizes, format ids, mountpoints, per-part crc32).
- **`tebakofs reassemble <dir> --output <file>`** — rebuilds from parts; recomputes geometry (part swaps and metadata edits honored); byte-identical when unchanged (asserted).
- **`tebakofs info <binary>`** — probes for a tpkg trailer first: valid → full slot dump; none → unchanged archive behavior; corrupt → named tpkg error.
- **Granular ops** — `insert-image` / `remove-image` / `set-runtime`: single-pass range-copy rewrite to temp + atomic rename; `remove-image` refuses the last slot.
- **`tebakofs mkimage --format dwarfs`** — mkdwarfs wrapper (PATH or `TEBAKO_MKDWARFS`). zip/squashfs rejected: zip backend is read-only, squashfs is LGPL.

New `src/cli/package.cpp` (+ `include/tebako/fs/cli/package.h`) hosts the single `TPKG_IMPLEMENTATION` TU.

## Tests

456/456 (422 pre-existing + 34 new in `tests/test_package.cpp`): golden round-trip byte-identity, manifest.json content incl. crc32 cross-checks, swap/edit reassembly, granular-ops slot tables and error paths, plain-image info (unit + e2e), mkimage magic, subprocess e2e via `TEBAKOFS_BINARY`.

## Notes

- Stacked behind #164 (both touch the tebakofs CMake target area); will rebase after #164 merges.
- Pre-existing quirk found, not fixed here: zip/squashfs `create_fixtures.sh` scripts write into the cwd (and one `rm -rf`s a tracked dir) — separate commit material.
