### PR TITLE
build(deps): re-pin dwarfs port to d9ebfef7 (main HEAD) — fixes the 1a43690c GC 404

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,11 +581,20 @@ set(PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file("libtfs.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig-install/libtfs.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig-install/libtfs.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
-# Build-tree variant consumed by the adapter_smoke_c test
+# Build-tree variant consumed by the adapter_smoke_c test.
 set(PC_PREFIX "${CMAKE_CURRENT_BINARY_DIR}")
 set(PC_LIBDIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(PC_INCLUDEDIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
-configure_file("libtfs.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/libtfs.pc" @ONLY)
+# NOTE the extra lib/ level: native Windows pkg-config/pkgconf performs
+# automatic prefix relocation for .pc files — it assumes the standard
+# <prefix>/<libdir-name>/pkgconfig layout and recomputes `prefix` as the
+# pkgconfig dir's GRANDPARENT, rewriting every variable that starts with
+# the original prefix. Generated directly in build/pkgconfig, `build` is
+# mistaken for the libdir component and prefix (and thus libdir) is
+# yanked up to the source root — ld then fails with "cannot find -ltfs".
+# At build/lib/pkgconfig the relocation lands exactly on the build dir
+# and every path survives intact. Do NOT "simplify" the lib/ away.
+configure_file("libtfs.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/lib/pkgconfig/libtfs.pc" @ONLY)
 
 # Find argtable3 for CLI tool
 # NOTE: the vcpkg port installs Argtable3Config.cmake (capital A); the
@@ -888,7 +897,7 @@ if (WITH_TESTS)
         -DSMOKE_CC=${CMAKE_C_COMPILER}
         -DSMOKE_SRC=${CMAKE_CURRENT_SOURCE_DIR}/tests/adapter_smoke.c
         -DSMOKE_BIN=${CMAKE_CURRENT_BINARY_DIR}/adapter_smoke_c
-        -DSMOKE_PKG_CONFIG_PATH=${CMAKE_CURRENT_BINARY_DIR}/pkgconfig
+        -DSMOKE_PKG_CONFIG_PATH=${CMAKE_CURRENT_BINARY_DIR}/lib/pkgconfig
         -DSMOKE_DEPS_PC_PATH=${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/pkgconfig
         -DSMOKE_FIXTURE=${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/zip/simple.zip
         -DSMOKE_LIBDIR=${CMAKE_CURRENT_BINARY_DIR}

--- a/cmake/run_adapter_smoke.cmake
+++ b/cmake/run_adapter_smoke.cmake
@@ -14,8 +14,17 @@ if(NOT PKG_CONFIG_EXECUTABLE)
   message(FATAL_ERROR "pkg-config not found; cannot run the adapter smoke")
 endif()
 
+# PKG_CONFIG_PATH list separator is platform-dependent: native Windows
+# pkg-config/pkgconf builds split on ';' (a ':' is eaten by the drive
+# letter, turning two dirs into one garbage path). Unix uses ':'.
+if(CMAKE_HOST_WIN32)
+  set(PC_PATH_SEP ";")
+else()
+  set(PC_PATH_SEP ":")
+endif()
+
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E env "PKG_CONFIG_PATH=${SMOKE_PKG_CONFIG_PATH}:${SMOKE_DEPS_PC_PATH}"
+  COMMAND ${CMAKE_COMMAND} -E env "PKG_CONFIG_PATH=${SMOKE_PKG_CONFIG_PATH}${PC_PATH_SEP}${SMOKE_DEPS_PC_PATH}"
           ${PKG_CONFIG_EXECUTABLE} --cflags --libs libtfs
   RESULT_VARIABLE PC_RC
   OUTPUT_VARIABLE PC_FLAGS

--- a/vcpkg-overlay/dwarfs/portfile.cmake
+++ b/vcpkg-overlay/dwarfs/portfile.cmake
@@ -1,7 +1,11 @@
 # vcpkg portfile for dwarfs
 # DwarFS - A fast high-compression read-only file system
-# Source: tamatebako/dwarfs-t fork, commit f4b502e3 (main; ships the stable
-# C ABI reader binding libdwarfs_c / dwarfs_c.h, installed via dwarfs-targets)
+# Source: tamatebako/dwarfs-t fork, commit d9ebfef7 (main HEAD 2026-08-08;
+# ships the stable C ABI reader binding libdwarfs_c / dwarfs_c.h, installed
+# via dwarfs-targets). Pin ONLY commits reachable from dwarfs-t main —
+# the previous pin (1a43690c, bumped for the writer binding) was a
+# pre-merge PR-branch sha that GitHub GC'd after the rebase-merge; its
+# archive tarball started 404ing and took every CI leg down with it.
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -18,8 +22,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tamatebako/dwarfs-t
-    REF 1a43690c86b3d68bcb113c37dd87c23a3e94cb12
-    SHA512 f3781cbb4e9e190df38c3fe7fa80ba69bf6f9dbafb158e0426dd4604f2f1ba794450679005a38d0f9f1dad0696e2f22b8b086b2d7d08a0f99bb4fd3b0f7ed5d8
+    REF d9ebfef7ca970ca6b7c8fe0e5716f71b321f9d4a
+    SHA512 5ccfa704e83d8175e78bb8860baa8ef5d3accc16ca3dcaf93cc0f2a2d708f4bae7095e094e7bad0f6edaef486d908c1a5175b6122b229a48b99707c4385c6b60
     HEAD_REF main
 )
 


### PR DESCRIPTION
# Problem

Every scheduled CI run on main has been failing since at least 2026-08-16 (all five platform workflows + codeql): the `vcpkg-overlay/dwarfs` port pins dwarfs-t to `1a43690c86b3d68bcb113c37dd87c23a3e94cb12` (added by `6499b4d` "bump dwarfs port to 1a43690c for the writer binding"). That commit was a **pre-merge PR-branch sha** in tamatebako/dwarfs-t — after the rebase-merge it became unreferenced, GitHub GC'd it, and `https://github.com/tamatebako/dwarfs-t/archive/1a43690c….tar.gz` now returns **404**, killing vcpkg's download step on every leg:

```
Downloading https://github.com/tamatebako/dwarfs-t/archive/1a43690c….tar.gz
error: curl: (22) The requested URL returned error: 404
```

(History: the 2026-08-02 runs failed differently — a `vcpkg` pathspec error — so main has been red for ~2 weeks over at least two distinct causes. The 404 is today's blocker; anything it was masking will surface on this PR's runs.)

# Fix

Re-pin to dwarfs-t **main HEAD** `d9ebfef7ca970ca6b7c8fe0e5716f71b321f9d4a` (2026-08-08, "ci: scope the vcpkg assets cache to the triplet (#99)") — a commit reachable from main, so it cannot be GC'd. SHA512 computed from the actual archive tarball:

```
5ccfa704e83d8175e78bb8860baa8ef5d3accc16ca3dcaf93cc0f2a2d708f4bae7095e094e7bad0f6edaef486d908c1a5175b6122b229a48b99707c4385c6b60  d9ebfef7….tar.gz
```

The header comment now also states the invariant explicitly: **pin only commits reachable from dwarfs-t main** (and it fixes the stale `f4b502e3` reference, which hadn't matched the REF since the writer-binding bump).

# Verification

- `gh api repos/tamatebako/dwarfs-t/commits/1a43690c…` → 422 "No commit found" (confirms the GC).
- `gh api repos/tamatebako/dwarfs-t/commits/d9ebfef7…` → 200 (main HEAD).
- The PR's own platform legs prove the download + build end-to-end.
