### PR TITLE
ci(lint): replace ls-glob with a nullglob array in package-deps.sh (SC2012)

### DIFF
--- a/.github/scripts/package-deps.sh
+++ b/.github/scripts/package-deps.sh
@@ -30,7 +30,12 @@ SHIP_TOOLCHAIN_RT="${SHIP_TOOLCHAIN_RT:-0}"
 
 cd "$WORKDIR"
 
-VILIB=$(ls -d build/vcpkg_installed/*/lib | head -1)
+# Exactly one triplet dir is expected under vcpkg_installed; take the first
+# sorted match and die loudly when the tree is missing (SC2012: no ls).
+shopt -s nullglob
+vi_libdirs=( build/vcpkg_installed/*/lib )
+shopt -u nullglob
+VILIB="${vi_libdirs[0]:?no build/vcpkg_installed/*/lib — run vcpkg install first}"
 VIROOT=$(dirname "$VILIB")
 LIBS="$DEPS_LIBS"
 SHARES="$DEPS_SHARES"


### PR DESCRIPTION
## What

Fixes the one shellcheck finding that has been failing the **lint** workflow on main: `SC2012` at `.github/scripts/package-deps.sh:33` (`ls -d build/vcpkg_installed/*/lib`).

## Why it went unnoticed

The lint workflow triggers on main pushes, not PRs — so it never appeared in PR checks, and it blended into the ~3 weeks of red main that #168 just fixed (see PROGRESS/06 at the ecosystem root for the full three-layer story).

## The change

`ls -d <glob> | head -1` → a `nullglob` array taking the first sorted match, dying loudly with a named message when the vcpkg tree is missing. Same value, same relative-path form, same fail-fast behavior.

## Verification

- `shellcheck -x` clean locally (same flags as the workflow's `SHELLCHECK_OPTS: -x`)
- `bash -n` clean
- Behavioral parity proven against a scratch `build/vcpkg_installed/x64-linux/lib` tree: `VIROOT` resolves to `build/vcpkg_installed/x64-linux` exactly as before
