### PR TITLE
build(deps): pin dwarfs by TAG v1.0.0 + add the pin-guard workflow

### DIFF
--- a/.github/workflows/pin-guard.yml
+++ b/.github/workflows/pin-guard.yml
@@ -1,0 +1,57 @@
+name: Pin guard
+
+# Enforces the dwarfs-t pin contract (owner decision 2026-08-16, see
+# vcpkg-overlay/dwarfs/portfile.cmake): REF must be an existing dwarfs-t
+# TAG — or, exceptionally, a 40-hex sha proven reachable from dwarfs-t
+# main. A pinned sha that is not on main can be orphaned by a
+# rebase-merge and garbage-collected by GitHub; its archive tarball then
+# 404s and takes every CI leg down with it (the 1a43690c incident, #168).
+
+on:
+  pull_request:
+    paths:
+      - 'vcpkg-overlay/**'
+  push:
+    branches: [main]
+    paths:
+      - 'vcpkg-overlay/**'
+
+permissions:
+  contents: read
+
+jobs:
+  dwarfs-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract the pinned REF
+        id: pin
+        run: |
+          REF=$(sed -n 's/^[[:space:]]*REF[[:space:]]\{1,\}\([^[:space:]]\{1,\}\)$/\1/p' vcpkg-overlay/dwarfs/portfile.cmake | head -1)
+          test -n "$REF" || { echo "::error::no REF found in vcpkg-overlay/dwarfs/portfile.cmake"; exit 1; }
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Assert the pin is a dwarfs-t tag or a main-reachable sha
+        run: |
+          set -euo pipefail
+          REF="${{ steps.pin.outputs.ref }}"
+          if git ls-remote --tags https://github.com/tamatebako/dwarfs-t "refs/tags/$REF" | grep -q .; then
+            echo "OK: '$REF' is an existing dwarfs-t tag (immutable anchor)."
+            exit 0
+          fi
+          if [[ "$REF" =~ ^[0-9a-f]{40}$ ]]; then
+            # Exceptional sha pin: must be reachable from dwarfs-t main.
+            rm -rf /tmp/dwarfs-t-check
+            git clone --quiet --filter=blob:none --no-checkout https://github.com/tamatebako/dwarfs-t /tmp/dwarfs-t-check
+            git -C /tmp/dwarfs-t-check fetch --quiet origin "$REF" || { echo "::error::sha $REF does not exist in tamatebako/dwarfs-t (GC'd or never pushed?)"; exit 1; }
+            if git -C /tmp/dwarfs-t-check merge-base --is-ancestor "$REF" origin/main; then
+              echo "OK: sha $REF is reachable from dwarfs-t main."
+              echo "::warning::sha pins are the exception — prefer a dwarfs-t tag (see the pin contract in the portfile)."
+              exit 0
+            fi
+            echo "::error::sha $REF exists but is NOT reachable from dwarfs-t main — a rebase-merge can orphan and GC it. Pin a tag instead."
+            exit 1
+          fi
+          echo "::error::REF '$REF' is neither an existing dwarfs-t tag nor a 40-hex sha."
+          exit 1

--- a/vcpkg-overlay/dwarfs/portfile.cmake
+++ b/vcpkg-overlay/dwarfs/portfile.cmake
@@ -1,11 +1,17 @@
 # vcpkg portfile for dwarfs
 # DwarFS - A fast high-compression read-only file system
-# Source: tamatebako/dwarfs-t fork, commit d9ebfef7 (main HEAD 2026-08-08;
-# ships the stable C ABI reader binding libdwarfs_c / dwarfs_c.h, installed
-# via dwarfs-targets). Pin ONLY commits reachable from dwarfs-t main —
-# the previous pin (1a43690c, bumped for the writer binding) was a
-# pre-merge PR-branch sha that GitHub GC'd after the rebase-merge; its
-# archive tarball started 404ing and took every CI leg down with it.
+# Source: tamatebako/dwarfs-t fork, tag v1.0.0 (commit d9ebfef7; ships the
+# stable C ABI reader binding libdwarfs_c / dwarfs_c.h, installed via
+# dwarfs-targets).
+#
+# PIN CONTRACT (owner decision 2026-08-16): pin TAGS of dwarfs-t, never
+# bare commit shas. A pre-merge PR-branch sha can be orphaned by a
+# rebase-merge and garbage-collected by GitHub — the 1a43690c pin's
+# archive tarball started 404ing and took every CI leg down with it
+# (~3 weeks of red main). Tags are immutable anchors: a tag never moves,
+# a new release is a new tag. The pin-guard workflow enforces this at PR
+# time (REF must be an existing dwarfs-t tag, or — exceptionally — a sha
+# proven reachable from dwarfs-t main).
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -22,8 +28,8 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tamatebako/dwarfs-t
-    REF d9ebfef7ca970ca6b7c8fe0e5716f71b321f9d4a
-    SHA512 5ccfa704e83d8175e78bb8860baa8ef5d3accc16ca3dcaf93cc0f2a2d708f4bae7095e094e7bad0f6edaef486d908c1a5175b6122b229a48b99707c4385c6b60
+    REF v1.0.0
+    SHA512 a0c70dd535cdcc3ad0967600fe41b21f52020b2f13a2a2c4b424f13019c22fd8c41a4a6e84a9717380bfe1dd11ea5658f0680cb614ae5ea789c0a5fe08e15051
     HEAD_REF main
 )
 

--- a/vcpkg-overlay/dwarfs/vcpkg.json
+++ b/vcpkg-overlay/dwarfs/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "dwarfs",
-  "version": "0.14.1",
+  "version": "1.0.0",
   "description": "DwarFS - A fast high-compression read-only file system",
   "homepage": "https://github.com/tamatebako/dwarfs-t",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## What

Two halves of the owner's pin-contract decision (2026-08-16), following the 1a43690c GC incident (#168):

1. **Pin dwarfs-t by tag.** The overlay port's REF moves from sha `d9ebfef7` to **`v1.0.0`** — an annotated tag on tamatebako/dwarfs-t pointing at that same commit, so this is a content-identical re-pin (the SHA512 is the *tag archive's*; the top-level dir changes to `dwarfs-t-1.0.0`). The overlay port version tracks the tag: `0.14.1 → 1.0.0`.
2. **Guard it in CI.** New `pin-guard.yml` runs whenever `vcpkg-overlay/**` changes (PRs and main pushes): extract the portfile REF and assert it is an existing dwarfs-t **tag** — or, exceptionally, a 40-hex sha proven **reachable from dwarfs-t main** (treeless clone + `merge-base --is-ancestor`). Anything else fails the PR, in minutes instead of after three weeks of red main.

## Why

A pre-merge PR-branch sha was pinned; the rebase-merge orphaned it; GitHub GC'd it; the archive 404'd; main was red ~3 weeks (full story: #168). Tags are immutable anchors — a tag never moves, a new release is a new tag.

## Verification

- Tag archive downloaded and hashed locally: `a0c70dd5…5051` matches the portfile.
- Guard logic dry-run against the real repo: `v1.0.0` passes via the tag path; `d9ebfef7` passes via the sha path (with the prefer-a-tag warning); the GC'd `1a43690c` fails as it must.
- CI on this PR rebuilds dwarfs from the tag archive on every platform leg (the port version bump changes the ABI hash — full-fidelity proof).

## Follow-up (not this PR)

dwarfs-t-rs consumes dwarfs-t via git dependency; when its pin next moves, it moves to a tag as well.
